### PR TITLE
feat: add statement handling in OSCAL component definition generated

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -43,15 +43,33 @@ jobs:
       - name: Zypper refresh
         run: zypper refresh    
       - name: Install Deps           
-        run: zypper install -y git cmake make bats openscap-utils python3 python3-rpm python3-pip python3-devel python3-PyYAML python3-Jinja2 python3-setuptools libxslt-tools libxml2-tools ShellCheck
+        run: |-
+          zypper install -y git cmake make bats openscap-utils python3 python3-rpm python3-pip python3-devel libxslt-tools libxml2-tools ShellCheck \
+          pyenv gcc bzip2 libbz2-devel xz xz-devel openssl-devel ncurses-devel readline-devel zlib-devel libffi-devel sqlite3-devel awk
+      - name: Install newer python version with pyenv
+        run: pyenv install 3.8.14
+      - name: Set up shell to use pyenv
+        run: |-
+          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+          echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+          echo 'eval "$(pyenv init -)"' >> ~/.bashrc
       - name: Upgrade pip python
-        run: pip install pip --upgrade
+        run: pyenv exec pip install pip --upgrade
+        env:
+          PYENV_VERSION: 3.8.14
       - name: Install deps python
-        run: pip install pytest pytest-cov
+        run: pyenv exec pip install compliance-trestle==2.4.0 PyYAML pytest pytest-cov Jinja2 setuptools
+        env:
+          PYENV_VERSION: 3.8.14
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build
-        run: ./build_product alinux2 alinux3 chromium fedora firefox rhcos4 rhel7 rhel8 rhel9 sle12 sle15 ubuntu2004 ubuntu2204 uos20
+        run: |-
+          source ~/.bashrc
+          pyenv shell 3.8.14
+          export PYTHONPATH="$PYENV_ROOT/versions/3.8.14/lib/python3.8/site-packages"
+          export ADDITIONAL_CMAKE_OPTIONS="-DPYTHON_EXECUTABLE=$PYENV_ROOT/versions/3.8.14/bin/python3.8"
+          ./build_product alinux2 alinux3 chromium fedora firefox rhcos4 rhel7 rhel8 rhel9 sle12 sle15 ubuntu2004 ubuntu2204 uos20
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -63,13 +81,33 @@ jobs:
       image: opensuse/leap:15
     steps:
       - name: Install Deps
-        run: zypper install -y git cmake make openscap-utils python3-PyYAML bats python3-pytest python3-pytest-cov python3-Jinja2 python3-setuptools libxslt-tools libxml2-tools ShellCheck
+        run: |-
+          zypper install -y git cmake make openscap-utils bats python3-pip libxslt-tools libxml2-tools ShellCheck \
+          pyenv tar gcc bzip2 libbz2-devel xz xz-devel openssl-devel ncurses-devel readline-devel zlib-devel tk-devel libffi-devel sqlite3-devel findutils
+      - name: Install newer python version with pyenv
+        run: pyenv install 3.8.14
+      - name: Set up shell to use pyenv
+        run: |-
+          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+          echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+          echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+      - name: Upgrade pip python
+        run: pyenv exec pip install pip --upgrade
+        env:
+          PYENV_VERSION: 3.8.14
+      - name: Install deps python
+        run: pyenv exec pip install compliance-trestle==2.4.0 PyYAML pytest pytest-cov Jinja2 setuptools
+        env:
+          PYENV_VERSION: 3.8.14
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build
-        run: ./build_product sle12 sle15
-        env:
-          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
+        run: |-
+          source ~/.bashrc
+          pyenv shell 3.8.14
+          export PYTHONPATH="$PYENV_ROOT/versions/3.8.14/lib/python3.8/site-packages"
+          export ADDITIONAL_CMAKE_OPTIONS="-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF -DPYTHON_EXECUTABLE=$PYENV_ROOT/versions/3.8.14/bin/python3.8"
+          ./build_product sle12 sle15
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -86,8 +124,10 @@ jobs:
         run: apt-get install -y ansible-lint bats check cmake libopenscap8 libxml2-utils ninja-build python3-github python3-pip xsltproc
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Upgrade pip python
+        run: pip3 install --upgrade pip 
       - name: Install deps python
-        run: pip3 install -r requirements.txt -r test-requirements.txt
+        run: pip3 install -r requirements.txt -r test-requirements.txt --ignore-installed PyYAML
       - name: Build
         env:
           ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
@@ -142,7 +182,7 @@ jobs:
       image: fedora:latest
     steps:
       - name: Install Deps
-        run: dnf install -y cmake make openscap-utils python3-pyyaml bats ansible python3-pip ShellCheck git
+        run: dnf install -y cmake make openscap-utils python3-pyyaml bats ansible python3-pip ShellCheck git python3-devel gcc-c++
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install deps python
@@ -190,7 +230,7 @@ jobs:
       -   name: Run Updates
           run: dnf update -y
       -   name: Install Deps
-          run: dnf install -y cmake make openscap-utils bats ansible python3-pip ShellCheck git
+          run: dnf install -y cmake make openscap-utils bats ansible python3-pip ShellCheck git python3-devel gcc-c++
       -   name: Checkout
           uses: actions/checkout@v4
       -   name: Install deps python

--- a/requirements-oscal.txt
+++ b/requirements-oscal.txt
@@ -1,3 +1,0 @@
--r requirements.txt
-# used in utils/oscal
-compliance-trestle

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ lxml
 pycompliance
 # used in utils/controleval_metrics.py
 prometheus_client
+# used in utils/oscal
+compliance-trestle==2.4.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
 xmldiff
 pytest
 pytest-cov
+# used in tests/units/utils/oscal
+compliance-trestle==2.4.0

--- a/tests/unit/utils/oscal/data/build-config.yml
+++ b/tests/unit/utils/oscal/data/build-config.yml
@@ -1,0 +1,10 @@
+cmake_build_type: "Release"
+
+ssg_version: [0, 1, 59]
+ssg_version_str: "0.1.59"
+target_oval_version: [5, 11]
+target_oval_version_str: "5.11"
+
+jinja2_cache_enabled: false
+
+sce_enabled: "OFF"

--- a/tests/unit/utils/oscal/data/rule_dirs.json
+++ b/tests/unit/utils/oscal/data/rule_dirs.json
@@ -1,0 +1,1 @@
+{"test_rule": {"id": "test_rule", "dir": "test_rule_dir", "guide": "test_rule_guide", "products": ["test_product"], "title": "My Test Rule", "identifiers": {}, "ovals": {}, "remediations": {"anaconda": {}, "ansible": {}, "bash": {}, "puppet": {}, "ignition": {}, "kubernetes": {}, "blueprint": {}}, "oval_products": {}, "remediation_products": {}}}

--- a/tests/unit/utils/oscal/data/simplified_nist_catalog.json
+++ b/tests/unit/utils/oscal/data/simplified_nist_catalog.json
@@ -1,0 +1,5225 @@
+{
+  "catalog": {
+    "uuid": "613fca2d-704a-42e7-8e2b-b206fb92b456",
+    "metadata": {
+      "title": "Trestle simplified: NIST Special Publication 800-53 Revision 5: Security and Privacy Controls for Federal Information Systems and Organizations",
+      "last-modified": "2021-06-08T13:57:33.013981-04:00",
+      "version": "5.0.1",
+      "oscal-version": "1.0.0",
+      "props": [
+        {
+          "name": "keywords",
+          "value": "assurance; availability; computer security; confidentiality; control; cybersecurity; FISMA; information security; information system; integrity; personally identifiable information; Privacy Act; privacy controls; privacy functions; privacy requirements; Risk Management Framework; security controls; security functions; security requirements; system; system security."
+        }
+      ],
+      "links": [
+        {
+          "href": "#c3397cc9-83c6-4459-adb2-836739dc1b94",
+          "rel": "alternate"
+        },
+        {
+          "href": "#f7cf488d-bc64-4a91-a994-810e153ee481",
+          "rel": "canonical"
+        }
+      ],
+      "roles": [
+        {
+          "id": "creator",
+          "title": "Document creator"
+        },
+        {
+          "id": "contact",
+          "title": "Contact"
+        }
+      ],
+      "parties": [
+        {
+          "uuid": "41a93829-b76b-43ec-b9e7-250553511549",
+          "type": "organization",
+          "name": "Joint Task Force, Interagency Working Group",
+          "email-addresses": [
+            "sec-cert@nist.gov"
+          ],
+          "addresses": [
+            {
+              "addr-lines": [
+                "National Institute of Standards and Technology",
+                "Attn: Computer Security Division"
+              ],
+              "city": "Gaithersburg",
+              "state": "MD",
+              "postal-code": "20899-8930"
+            }
+          ]
+        }
+      ],
+      "responsible-parties": [
+        {
+          "role-id": "creator",
+          "party-uuids": [
+            "41a93829-b76b-43ec-b9e7-250553511549"
+          ]
+        },
+        {
+          "role-id": "contact",
+          "party-uuids": [
+            "41a93829-b76b-43ec-b9e7-250553511549"
+          ]
+        }
+      ]
+    },
+    "params": [
+      {
+        "id": "loose_1",
+        "label": "loose_1_label",
+        "values": [
+          "loose_1_value"
+        ]
+      },
+      {
+        "id": "loose_2",
+        "label": "loose_2_label",
+        "values": [
+          "loose_2_value"
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "id": "ac",
+        "class": "family",
+        "title": "Access Control",
+        "controls": [
+          {
+            "id": "ac-1",
+            "class": "SP800-53",
+            "title": "Policy and Procedures",
+            "params": [
+              {
+                "id": "ac-1_prm_1",
+                "props": [
+                  {
+                    "name": "param_1_prop",
+                    "value": "prop value"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#123456789",
+                    "text": "orig link text"
+                  }
+                ],
+                "label": "organization-defined personnel or roles",
+                "constraints": [
+                  {
+                    "description": "orig constraint desc"
+                  }
+                ],
+                "guidelines": [
+                  {
+                    "prose": "original guideline"
+                  }
+                ],
+                "values": [
+                  "Param_1_value_in_catalog"
+                ]
+              },
+              {
+                "id": "ac-1_prm_2",
+                "select": {
+                  "how-many": "one-or-more",
+                  "choice": [
+                    "Organization-level",
+                    "Mission/business process-level",
+                    "System-level"
+                  ]
+                }
+              },
+              {
+                "id": "ac-1_prm_3",
+                "label": "organization-defined official"
+              },
+              {
+                "id": "ac-1_prm_4",
+                "label": "organization-defined frequency"
+              },
+              {
+                "id": "ac-1_prm_5",
+                "label": "organization-defined events"
+              },
+              {
+                "id": "ac-1_prm_6",
+                "label": "organization-defined frequency"
+              },
+              {
+                "id": "ac-1_prm_7",
+                "label": "organization-defined events"
+              }
+            ],
+            "props": [
+              {
+                "name": "label",
+                "value": "AC-1"
+              },
+              {
+                "name": "sort-id",
+                "value": "ac-01"
+              },
+              {
+                "name": "extra_prop",
+                "value": "extra value"
+              }
+            ],
+            "links": [
+              {
+                "href": "#27847491-5ce1-4f6a-a1e4-9e483782f0ef",
+                "rel": "reference"
+              },
+              {
+                "href": "#c7ac44e8-10db-4b64-b2b9-9e32ec1efed0",
+                "rel": "reference"
+              },
+              {
+                "href": "#08b07465-dbdc-48d6-8a0b-37279602ac16",
+                "rel": "reference"
+              },
+              {
+                "href": "#cec037f3-8aba-4c97-84b4-4082f9e515d2",
+                "rel": "reference"
+              },
+              {
+                "href": "#4c0ec2ee-a0d6-428a-9043-4504bc3ade6f",
+                "rel": "reference"
+              },
+              {
+                "href": "#7f473f21-fdbf-4a6c-81a1-0ab95919609d",
+                "rel": "reference"
+              },
+              {
+                "href": "#ia-1",
+                "rel": "related"
+              },
+              {
+                "href": "#pm-9",
+                "rel": "related"
+              },
+              {
+                "href": "#pm-24",
+                "rel": "related"
+              },
+              {
+                "href": "#ps-8",
+                "rel": "related"
+              },
+              {
+                "href": "#si-12",
+                "rel": "related"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ac-1_smt",
+                "name": "statement",
+                "prose": "The organization:",
+                "parts": [
+                  {
+                    "id": "ac-1_smt.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "a."
+                      }
+                    ],
+                    "prose": "Develop, document, and disseminate to {{ insert: param, ac-1_prm_1 }}:",
+                    "parts": [
+                      {
+                        "id": "ac-1_smt.a.1",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "1."
+                          }
+                        ],
+                        "prose": " {{ insert: param, ac-1_prm_2 }} access control policy that:",
+                        "parts": [
+                          {
+                            "id": "ac-1_smt.a.1.a",
+                            "name": "item",
+                            "props": [
+                              {
+                                "name": "label",
+                                "value": "(a)"
+                              }
+                            ],
+                            "prose": "Addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and"
+                          },
+                          {
+                            "id": "ac-1_smt.a.1.b",
+                            "name": "item",
+                            "props": [
+                              {
+                                "name": "label",
+                                "value": "(b)"
+                              }
+                            ],
+                            "prose": "Is consistent with applicable laws, executive orders, directives, regulations, policies, standards, and guidelines; and"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "ac-1_smt.a.2",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "2."
+                          }
+                        ],
+                        "prose": "Procedures to facilitate the implementation of the access control policy and the associated access controls;"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-1_smt.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "b."
+                      }
+                    ],
+                    "prose": "Designate an {{ insert: param, ac-1_prm_3 }} to manage the development, documentation, and dissemination of the access control policy and procedures; and"
+                  },
+                  {
+                    "id": "ac-1_smt.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "c."
+                      }
+                    ],
+                    "prose": "Review and update the current access control:",
+                    "parts": [
+                      {
+                        "id": "ac-1_smt.c.1",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "1."
+                          }
+                        ],
+                        "prose": "Policy {{ insert: param, ac-1_prm_4 }} and following {{ insert: param, ac-1_prm_5 }}; and"
+                      },
+                      {
+                        "id": "ac-1_smt.c.2",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "2."
+                          }
+                        ],
+                        "prose": "Procedures {{ insert: param, ac-1_prm_6 }} and following {{ insert: param, ac-1_prm_7 }}."
+                      }
+                    ]
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "prop_in_part",
+                    "value": "value in part"
+                  }
+                ]
+              },
+              {
+                "id": "ac-1_gdn",
+                "name": "guidance",
+                "prose": "Access control policy and procedures address the controls in the AC family that are implemented within systems and organizations. The risk management strategy is an important factor in establishing such policies and procedures. Policies and procedures contribute to security and privacy assurance. Therefore, it is important that security and privacy programs collaborate on the development of access control policy and procedures. Security and privacy program policies and procedures at the organization level are preferable, in general, and may obviate the need for mission- or system-specific policies and procedures. The policy can be included as part of the general security and privacy policy or be represented by multiple policies reflecting the complex nature of organizations. Procedures can be established for security and privacy programs, for mission or business processes, and for systems, if needed. Procedures describe how the policies or controls are implemented and can be directed at the individual or role that is the object of the procedure. Procedures can be documented in system security and privacy plans or in one or more separate documents. Events that may precipitate an update to access control policy and procedures include assessment or audit findings, security incidents or breaches, or changes in laws, executive orders, directives, regulations, policies, standards, and guidelines. Simply restating controls does not constitute an organizational policy or procedure."
+              }
+            ]
+          },
+          {
+            "id": "ac-2",
+            "class": "SP800-53",
+            "title": "Account Management",
+            "params": [
+              {
+                "id": "ac-2_prm_1",
+                "label": "organization-defined prerequisites and criteria"
+              },
+              {
+                "id": "ac-2_prm_2",
+                "label": "organization-defined attributes (as required)"
+              },
+              {
+                "id": "ac-2_prm_3",
+                "label": "organization-defined personnel or roles"
+              },
+              {
+                "id": "ac-2_prm_4",
+                "label": "organization-defined policy, procedures, prerequisites, and criteria"
+              },
+              {
+                "id": "ac-2_prm_5",
+                "label": "organization-defined personnel or roles"
+              },
+              {
+                "id": "ac-2_prm_6",
+                "label": "organization-defined time period"
+              },
+              {
+                "id": "ac-2_prm_7",
+                "label": "organization-defined time period"
+              },
+              {
+                "id": "ac-2_prm_8",
+                "label": "organization-defined time period"
+              },
+              {
+                "id": "ac-2_prm_9",
+                "label": "organization-defined attributes (as required)"
+              },
+              {
+                "id": "ac-2_prm_10",
+                "label": "organization-defined frequency"
+              }
+            ],
+            "props": [
+              {
+                "name": "label",
+                "value": "AC-2"
+              },
+              {
+                "name": "sort-id",
+                "value": "ac-02"
+              }
+            ],
+            "links": [
+              {
+                "href": "#2956e175-f674-43f4-b1b9-e074ad9fc39c",
+                "rel": "reference"
+              },
+              {
+                "href": "#388a3aa2-5d85-4bad-b8a3-77db80d63c4f",
+                "rel": "reference"
+              },
+              {
+                "href": "#53df282b-8b3f-483a-bad1-6a8b8ac00114",
+                "rel": "reference"
+              },
+              {
+                "href": "#ac-3",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-5",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-6",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-17",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-18",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-20",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-24",
+                "rel": "related"
+              },
+              {
+                "href": "#au-2",
+                "rel": "related"
+              },
+              {
+                "href": "#au-12",
+                "rel": "related"
+              },
+              {
+                "href": "#cm-5",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-2",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-4",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-5",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-8",
+                "rel": "related"
+              },
+              {
+                "href": "#ma-3",
+                "rel": "related"
+              },
+              {
+                "href": "#ma-5",
+                "rel": "related"
+              },
+              {
+                "href": "#pe-2",
+                "rel": "related"
+              },
+              {
+                "href": "#pl-4",
+                "rel": "related"
+              },
+              {
+                "href": "#ps-2",
+                "rel": "related"
+              },
+              {
+                "href": "#ps-4",
+                "rel": "related"
+              },
+              {
+                "href": "#ps-5",
+                "rel": "related"
+              },
+              {
+                "href": "#ps-7",
+                "rel": "related"
+              },
+              {
+                "href": "#pt-2",
+                "rel": "related"
+              },
+              {
+                "href": "#pt-3",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-7",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-12",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-13",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-37",
+                "rel": "related"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ac-2_smt",
+                "name": "statement",
+                "parts": [
+                  {
+                    "id": "ac-2_smt.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "a."
+                      }
+                    ],
+                    "prose": "Define and document the types of accounts allowed and specifically prohibited for use within the system;"
+                  },
+                  {
+                    "id": "ac-2_smt.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "b."
+                      }
+                    ],
+                    "prose": "Assign account managers;"
+                  },
+                  {
+                    "id": "ac-2_smt.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "c."
+                      }
+                    ],
+                    "prose": "Require {{ insert: param, ac-2_prm_1 }} for group and role membership;"
+                  },
+                  {
+                    "id": "ac-2_smt.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "d."
+                      }
+                    ],
+                    "prose": "Specify:",
+                    "parts": [
+                      {
+                        "id": "ac-2_smt.d.1",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "1."
+                          }
+                        ],
+                        "prose": "Authorized users of the system;"
+                      },
+                      {
+                        "id": "ac-2_smt.d.2",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "2."
+                          }
+                        ],
+                        "prose": "Group and role membership; and"
+                      },
+                      {
+                        "id": "ac-2_smt.d.3",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "3."
+                          }
+                        ],
+                        "prose": "Access authorizations (i.e., privileges) and {{ insert: param, ac-2_prm_2 }} for each account;"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-2_smt.e",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "e."
+                      }
+                    ],
+                    "prose": "Require approvals by {{ insert: param, ac-2_prm_3 }} for requests to create accounts;"
+                  },
+                  {
+                    "id": "ac-2_smt.f",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "f."
+                      }
+                    ],
+                    "prose": "Create, enable, modify, disable, and remove accounts in accordance with {{ insert: param, ac-2_prm_4 }};"
+                  },
+                  {
+                    "id": "ac-2_smt.g",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "g."
+                      }
+                    ],
+                    "prose": "Monitor the use of accounts;"
+                  },
+                  {
+                    "id": "ac-2_smt.h",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "h."
+                      }
+                    ],
+                    "prose": "Notify account managers and {{ insert: param, ac-2_prm_5 }} within:",
+                    "parts": [
+                      {
+                        "id": "ac-2_smt.h.1",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "1."
+                          }
+                        ],
+                        "prose": " {{ insert: param, ac-2_prm_6 }} when accounts are no longer required;"
+                      },
+                      {
+                        "id": "ac-2_smt.h.2",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "2."
+                          }
+                        ],
+                        "prose": " {{ insert: param, ac-2_prm_7 }} when users are terminated or transferred; and"
+                      },
+                      {
+                        "id": "ac-2_smt.h.3",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "3."
+                          }
+                        ],
+                        "prose": " {{ insert: param, ac-2_prm_8 }} when system usage or need-to-know changes for an individual;"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-2_smt.i",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "i."
+                      }
+                    ],
+                    "prose": "Authorize access to the system based on:",
+                    "parts": [
+                      {
+                        "id": "ac-2_smt.i.1",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "1."
+                          }
+                        ],
+                        "prose": "A valid access authorization;"
+                      },
+                      {
+                        "id": "ac-2_smt.i.2",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "2."
+                          }
+                        ],
+                        "prose": "Intended system usage; and"
+                      },
+                      {
+                        "id": "ac-2_smt.i.3",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "3."
+                          }
+                        ],
+                        "prose": " {{ insert: param, ac-2_prm_9 }};"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-2_smt.j",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "j."
+                      }
+                    ],
+                    "prose": "Review accounts for compliance with account management requirements {{ insert: param, ac-2_prm_10 }};"
+                  },
+                  {
+                    "id": "ac-2_smt.k",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "k."
+                      }
+                    ],
+                    "prose": "Establish and implement a process for changing shared or group account authenticators (if deployed) when individuals are removed from the group; and"
+                  },
+                  {
+                    "id": "ac-2_smt.l",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "l."
+                      }
+                    ],
+                    "prose": "Align account management processes with personnel termination and transfer processes."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2_gdn",
+                "name": "guidance",
+                "prose": "Examples of system account types include individual, shared, group, system, guest, anonymous, emergency, developer, temporary, and service. Identification of authorized system users and the specification of access privileges reflect the requirements in other controls in the security plan. Users requiring administrative privileges on system accounts receive additional scrutiny by organizational personnel responsible for approving such accounts and privileged access, including system owner, mission or business owner, senior agency information security officer, or senior agency official for privacy. Types of accounts that organizations may wish to prohibit due to increased risk include shared, group, emergency, anonymous, temporary, and guest accounts.\n\nWhere access involves personally identifiable information, security programs collaborate with the senior agency official for privacy to establish the specific conditions for group and role membership; specify authorized users, group and role membership, and access authorizations for each account; and create, adjust, or remove system accounts in accordance with organizational policies. Policies can include such information as account expiration dates or other factors that trigger the disabling of accounts. Organizations may choose to define access privileges or other attributes by account, type of account, or a combination of the two. Examples of other attributes required for authorizing access include restrictions on time of day, day of week, and point of origin. In defining other system account attributes, organizations consider system-related requirements and mission/business requirements. Failure to consider these factors could affect system availability.\n\nTemporary and emergency accounts are intended for short-term use. Organizations establish temporary accounts as part of normal account activation procedures when there is a need for short-term accounts without the demand for immediacy in account activation. Organizations establish emergency accounts in response to crisis situations and with the need for rapid account activation. Therefore, emergency account activation may bypass normal account authorization processes. Emergency and temporary accounts are not to be confused with infrequently used accounts, including local logon accounts used for special tasks or when network resources are unavailable (may also be known as accounts of last resort). Such accounts remain available and are not subject to automatic disabling or removal dates. Conditions for disabling or deactivating accounts include when shared/group, emergency, or temporary accounts are no longer required and when individuals are transferred or terminated. Changing shared/group authenticators when members leave the group is intended to ensure that former group members do not retain access to the shared or group account. Some types of system accounts may require specialized training."
+              }
+            ],
+            "controls": [
+              {
+                "id": "ac-2.1",
+                "class": "SP800-53-enhancement",
+                "title": "Automated System Account Management",
+                "params": [
+                  {
+                    "id": "ac-2.1_prm_1",
+                    "label": "organization-defined automated mechanisms"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(1)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.01"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.1_smt",
+                    "name": "statement",
+                    "prose": "Support the management of system accounts using {{ insert: param, ac-2.1_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-2.1_gdn",
+                    "name": "guidance",
+                    "prose": "Automated system account management includes using automated mechanisms to create, enable, modify, disable, and remove accounts; notify account managers when an account is created, enabled, modified, disabled, or removed, or when users are terminated or transferred; monitor system account usage; and report atypical system account usage. Automated mechanisms can include internal system functions and email, telephonic, and text messaging notifications."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.2",
+                "class": "SP800-53-enhancement",
+                "title": "Automated Temporary and Emergency Account Management",
+                "params": [
+                  {
+                    "id": "ac-2.2_prm_1",
+                    "select": {
+                      "choice": [
+                        "remove",
+                        "disable"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ac-2.2_prm_2",
+                    "label": "organization-defined time period for each type of account"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(2)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.02"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.2_smt",
+                    "name": "statement",
+                    "prose": "Automatically {{ insert: param, ac-2.2_prm_1 }} temporary and emergency accounts after {{ insert: param, ac-2.2_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-2.2_gdn",
+                    "name": "guidance",
+                    "prose": "Management of temporary and emergency accounts includes the removal or disabling of such accounts automatically after a predefined time period rather than at the convenience of the system administrator. Automatic removal or disabling of accounts provides a more consistent implementation."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.3",
+                "class": "SP800-53-enhancement",
+                "title": "Disable Accounts",
+                "params": [
+                  {
+                    "id": "ac-2.3_prm_1",
+                    "label": "organization-defined time period"
+                  },
+                  {
+                    "id": "ac-2.3_prm_2",
+                    "label": "organization-defined time period"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(3)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.03"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.3_smt",
+                    "name": "statement",
+                    "prose": "Disable accounts within {{ insert: param, ac-2.3_prm_1 }} when the accounts:",
+                    "parts": [
+                      {
+                        "id": "ac-2.3_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Have expired;"
+                      },
+                      {
+                        "id": "ac-2.3_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Are no longer associated with a user or individual;"
+                      },
+                      {
+                        "id": "ac-2.3_smt.c",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(c)"
+                          }
+                        ],
+                        "prose": "Are in violation of organizational policy; or"
+                      },
+                      {
+                        "id": "ac-2.3_smt.d",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(d)"
+                          }
+                        ],
+                        "prose": "Have been inactive for {{ insert: param, ac-2.3_prm_2 }}."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-2.3_gdn",
+                    "name": "guidance",
+                    "prose": "Disabling expired, inactive, or otherwise anomalous accounts supports the concepts of least privilege and least functionality which reduce the attack surface of the system."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.4",
+                "class": "SP800-53-enhancement",
+                "title": "Automated Audit Actions",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(4)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.04"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#au-2",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-6",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.4_smt",
+                    "name": "statement",
+                    "prose": "Automatically audit account creation, modification, enabling, disabling, and removal actions."
+                  },
+                  {
+                    "id": "ac-2.4_gdn",
+                    "name": "guidance",
+                    "prose": "Account management audit records are defined in accordance with [AU-2](#au-2) and reviewed, analyzed, and reported in accordance with [AU-6](#au-6)."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.5",
+                "class": "SP800-53-enhancement",
+                "title": "Inactivity Logout",
+                "params": [
+                  {
+                    "id": "ac-2.5_prm_1",
+                    "label": "organization-defined time period of expected inactivity or description of when to log out"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(5)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.05"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ac-11",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.5_smt",
+                    "name": "statement",
+                    "prose": "Require that users log out when {{ insert: param, ac-2.5_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-2.5_gdn",
+                    "name": "guidance",
+                    "prose": "Inactivity logout is behavior- or policy-based and requires users to take physical action to log out when they are expecting inactivity longer than the defined period. Automatic enforcement of inactivity logout is addressed by [AC-11](#ac-11)."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.6",
+                "class": "SP800-53-enhancement",
+                "title": "Dynamic Privilege Management",
+                "params": [
+                  {
+                    "id": "ac-2.6_prm_1",
+                    "label": "organization-defined dynamic privilege management capabilities"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(6)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.06"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ac-16",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.6_smt",
+                    "name": "statement",
+                    "prose": "Implement {{ insert: param, ac-2.6_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-2.6_gdn",
+                    "name": "guidance",
+                    "prose": "In contrast to access control approaches that employ static accounts and predefined user privileges, dynamic access control approaches rely on runtime access control decisions facilitated by dynamic privilege management, such as attribute-based access control. While user identities remain relatively constant over time, user privileges typically change more frequently based on ongoing mission or business requirements and the operational needs of organizations. An example of dynamic privilege management is the immediate revocation of privileges from users as opposed to requiring that users terminate and restart their sessions to reflect changes in privileges. Dynamic privilege management can also include mechanisms that change user privileges based on dynamic rules as opposed to editing specific user profiles. Examples include automatic adjustments of user privileges if they are operating out of their normal work times, if their job function or assignment changes, or if systems are under duress or in emergency situations. Dynamic privilege management includes the effects of privilege changes, for example, when there are changes to encryption keys used for communications."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.7",
+                "class": "SP800-53-enhancement",
+                "title": "Privileged User Accounts",
+                "params": [
+                  {
+                    "id": "ac-2.7_prm_1",
+                    "select": {
+                      "choice": [
+                        "a role-based access scheme",
+                        "an attribute-based access scheme"
+                      ]
+                    }
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(7)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.07"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.7_smt",
+                    "name": "statement",
+                    "parts": [
+                      {
+                        "id": "ac-2.7_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Establish and administer privileged user accounts in accordance with {{ insert: param, ac-2.7_prm_1 }};"
+                      },
+                      {
+                        "id": "ac-2.7_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Monitor privileged role or attribute assignments;"
+                      },
+                      {
+                        "id": "ac-2.7_smt.c",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(c)"
+                          }
+                        ],
+                        "prose": "Monitor changes to roles or attributes; and"
+                      },
+                      {
+                        "id": "ac-2.7_smt.d",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(d)"
+                          }
+                        ],
+                        "prose": "Revoke access when privileged role or attribute assignments are no longer appropriate."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-2.7_gdn",
+                    "name": "guidance",
+                    "prose": "Privileged roles are organization-defined roles assigned to individuals that allow those individuals to perform certain security-relevant functions that ordinary users are not authorized to perform. Privileged roles include key management, account management, database administration, system and network administration, and web administration. A role-based access scheme organizes permitted system access and privileges into roles. In contrast, an attribute-based access scheme specifies allowed system access and privileges based on attributes."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.8",
+                "class": "SP800-53-enhancement",
+                "title": "Dynamic Account Management",
+                "params": [
+                  {
+                    "id": "ac-2.8_prm_1",
+                    "label": "organization-defined system accounts"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(8)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.08"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ac-16",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.8_smt",
+                    "name": "statement",
+                    "prose": "Create, activate, manage, and deactivate {{ insert: param, ac-2.8_prm_1 }} dynamically."
+                  },
+                  {
+                    "id": "ac-2.8_gdn",
+                    "name": "guidance",
+                    "prose": "Approaches for dynamically creating, activating, managing, and deactivating system accounts rely on automatically provisioning the accounts at runtime for entities that were previously unknown. Organizations plan for the dynamic management, creation, activation, and deactivation of system accounts by establishing trust relationships, business rules, and mechanisms with appropriate authorities to validate related authorizations and privileges."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.9",
+                "class": "SP800-53-enhancement",
+                "title": "Restrictions on Use of Shared and Group Accounts",
+                "params": [
+                  {
+                    "id": "ac-2.9_prm_1",
+                    "label": "organization-defined conditions for establishing shared and group accounts"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(9)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.09"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.9_smt",
+                    "name": "statement",
+                    "prose": "Only permit the use of shared and group accounts that meet {{ insert: param, ac-2.9_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-2.9_gdn",
+                    "name": "guidance",
+                    "prose": "Before permitting the use of shared or group accounts, organizations consider the increased risk due to the lack of accountability with such accounts."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.10",
+                "class": "SP800-53-enhancement",
+                "title": "Shared and Group Account Credential Change",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(10)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.10"
+                  },
+                  {
+                    "name": "status",
+                    "value": "withdrawn"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2_smt.k",
+                    "rel": "incorporated-into"
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.11",
+                "class": "SP800-53-enhancement",
+                "title": "Usage Conditions",
+                "params": [
+                  {
+                    "id": "ac-2.11_prm_1",
+                    "label": "organization-defined circumstances and/or usage conditions"
+                  },
+                  {
+                    "id": "ac-2.11_prm_2",
+                    "label": "organization-defined system accounts"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(11)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.11"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.11_smt",
+                    "name": "statement",
+                    "prose": "Enforce {{ insert: param, ac-2.11_prm_1 }} for {{ insert: param, ac-2.11_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-2.11_gdn",
+                    "name": "guidance",
+                    "prose": "Specifying and enforcing usage conditions helps to enforce the principle of least privilege, increase user accountability, and enable effective account monitoring. Account monitoring includes alerts generated if the account is used in violation of organizational parameters. Organizations can describe specific conditions or circumstances under which system accounts can be used, such as by restricting usage to certain days of the week, time of day, or specific durations of time."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.12",
+                "class": "SP800-53-enhancement",
+                "title": "Account Monitoring for Atypical Usage",
+                "params": [
+                  {
+                    "id": "ac-2.12_prm_1",
+                    "label": "organization-defined atypical usage"
+                  },
+                  {
+                    "id": "ac-2.12_prm_2",
+                    "label": "organization-defined personnel or roles"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(12)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.12"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#au-6",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-7",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ca-7",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ir-8",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#si-4",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.12_smt",
+                    "name": "statement",
+                    "parts": [
+                      {
+                        "id": "ac-2.12_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Monitor system accounts for {{ insert: param, ac-2.12_prm_1 }}; and"
+                      },
+                      {
+                        "id": "ac-2.12_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Report atypical usage of system accounts to {{ insert: param, ac-2.12_prm_2 }}."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-2.12_gdn",
+                    "name": "guidance",
+                    "prose": "Atypical usage includes accessing systems at certain times of the day or from locations that are not consistent with the normal usage patterns of individuals. Monitoring for atypical usage may reveal rogue behavior by individuals or an attack in progress. Account monitoring may inadvertently create privacy risks since data collected to identify atypical usage may reveal previously unknown information about the behavior of individuals. Organizations assess and document privacy risks from monitoring accounts for atypical usage in their privacy impact assessment and make determinations that are in alignment with their privacy program plan."
+                  }
+                ]
+              },
+              {
+                "id": "ac-2.13",
+                "class": "SP800-53-enhancement",
+                "title": "Disable Accounts for High-risk Individuals",
+                "params": [
+                  {
+                    "id": "ac-2.13_prm_1",
+                    "label": "organization-defined time period"
+                  },
+                  {
+                    "id": "ac-2.13_prm_2",
+                    "label": "organization-defined significant risks"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-2(13)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-02.13"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-2",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#au-6",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#si-4",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-2.13_smt",
+                    "name": "statement",
+                    "prose": "Disable accounts of individuals within {{ insert: param, ac-2.13_prm_1 }} of discovery of {{ insert: param, ac-2.13_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-2.13_gdn",
+                    "name": "guidance",
+                    "prose": "Users who pose a significant security and/or privacy risk include individuals for whom reliable evidence indicates either the intention to use authorized access to systems to cause harm or through whom adversaries will cause harm. Such harm includes adverse impacts to organizational operations, organizational assets, individuals, other organizations, or the Nation. Close coordination among system administrators, legal staff, human resource managers, and authorizing officials is essential when disabling system accounts for high-risk individuals."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ac-3",
+            "class": "SP800-53",
+            "title": "Access Enforcement",
+            "props": [
+              {
+                "name": "label",
+                "value": "AC-3"
+              },
+              {
+                "name": "sort-id",
+                "value": "ac-03"
+              }
+            ],
+            "links": [
+              {
+                "href": "#18e71fec-c6fd-475a-925a-5d8495cf8455",
+                "rel": "reference"
+              },
+              {
+                "href": "#27847491-5ce1-4f6a-a1e4-9e483782f0ef",
+                "rel": "reference"
+              },
+              {
+                "href": "#110e26af-4765-49e1-8740-6750f83fcda1",
+                "rel": "reference"
+              },
+              {
+                "href": "#e7942589-e267-4a5a-a3d9-f39a7aae81f0",
+                "rel": "reference"
+              },
+              {
+                "href": "#8306620b-1920-4d73-8b21-12008528595f",
+                "rel": "reference"
+              },
+              {
+                "href": "#2956e175-f674-43f4-b1b9-e074ad9fc39c",
+                "rel": "reference"
+              },
+              {
+                "href": "#388a3aa2-5d85-4bad-b8a3-77db80d63c4f",
+                "rel": "reference"
+              },
+              {
+                "href": "#7f473f21-fdbf-4a6c-81a1-0ab95919609d",
+                "rel": "reference"
+              },
+              {
+                "href": "#ac-2",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-4",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-5",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-6",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-16",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-17",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-18",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-19",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-20",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-21",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-22",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-24",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-25",
+                "rel": "related"
+              },
+              {
+                "href": "#at-2",
+                "rel": "related"
+              },
+              {
+                "href": "#at-3",
+                "rel": "related"
+              },
+              {
+                "href": "#au-9",
+                "rel": "related"
+              },
+              {
+                "href": "#ca-9",
+                "rel": "related"
+              },
+              {
+                "href": "#cm-5",
+                "rel": "related"
+              },
+              {
+                "href": "#cm-11",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-2",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-5",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-6",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-7",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-11",
+                "rel": "related"
+              },
+              {
+                "href": "#ma-3",
+                "rel": "related"
+              },
+              {
+                "href": "#ma-4",
+                "rel": "related"
+              },
+              {
+                "href": "#ma-5",
+                "rel": "related"
+              },
+              {
+                "href": "#mp-4",
+                "rel": "related"
+              },
+              {
+                "href": "#pm-2",
+                "rel": "related"
+              },
+              {
+                "href": "#ps-3",
+                "rel": "related"
+              },
+              {
+                "href": "#pt-2",
+                "rel": "related"
+              },
+              {
+                "href": "#pt-3",
+                "rel": "related"
+              },
+              {
+                "href": "#sa-17",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-2",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-3",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-4",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-12",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-13",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-28",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-31",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-34",
+                "rel": "related"
+              },
+              {
+                "href": "#si-4",
+                "rel": "related"
+              },
+              {
+                "href": "#si-8",
+                "rel": "related"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ac-3_smt",
+                "name": "statement",
+                "prose": "Enforce approved authorizations for logical access to information and system resources in accordance with applicable access control policies."
+              },
+              {
+                "id": "ac-3_gdn",
+                "name": "guidance",
+                "prose": "Access control policies control access between active entities or subjects (i.e., users or processes acting on behalf of users) and passive entities or objects (i.e., devices, files, records, domains) in organizational systems. In addition to enforcing authorized access at the system level and recognizing that systems can host many applications and services in support of mission and business functions, access enforcement mechanisms can also be employed at the application and service level to provide increased information security and privacy. In contrast to logical access controls that are implemented within the system, physical access controls are addressed by the controls in the Physical and Environmental Protection ([PE](#pe)) family."
+              }
+            ],
+            "controls": [
+              {
+                "id": "ac-3.1",
+                "class": "SP800-53-enhancement",
+                "title": "Restricted Access to Privileged Functions",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(1)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.01"
+                  },
+                  {
+                    "name": "status",
+                    "value": "withdrawn"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "incorporated-into"
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.2",
+                "class": "SP800-53-enhancement",
+                "title": "Dual Authorization",
+                "params": [
+                  {
+                    "id": "ac-3.2_prm_1",
+                    "label": "organization-defined privileged commands and/or other organization-defined actions"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(2)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.02"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#cp-9",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#mp-6",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.2_smt",
+                    "name": "statement",
+                    "prose": "Enforce dual authorization for {{ insert: param, ac-3.2_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-3.2_gdn",
+                    "name": "guidance",
+                    "prose": "Dual authorization, also known as two-person control, reduces risk related to insider threats. Dual authorization mechanisms require the approval of two authorized individuals to execute. To reduce the risk of collusion, organizations consider rotating dual authorization duties. Organizations consider the risk associated with implementing dual authorization mechanisms when immediate responses are necessary to ensure public and environmental safety."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.3",
+                "class": "SP800-53-enhancement",
+                "title": "Mandatory Access Control",
+                "params": [
+                  {
+                    "id": "ac-3.3_prm_1",
+                    "label": "organization-defined mandatory access control policy"
+                  },
+                  {
+                    "id": "ac-3.3_prm_2",
+                    "label": "organization-defined subjects"
+                  },
+                  {
+                    "id": "ac-3.3_prm_3",
+                    "label": "organization-defined privileges"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(3)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.03"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#sc-7",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.3_smt",
+                    "name": "statement",
+                    "prose": "Enforce {{ insert: param, ac-3.3_prm_1 }} over the set of covered subjects and objects specified in the policy, and where the policy:",
+                    "parts": [
+                      {
+                        "id": "ac-3.3_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Is uniformly enforced across the covered subjects and objects within the system;"
+                      },
+                      {
+                        "id": "ac-3.3_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Specifies that a subject that has been granted access to information is constrained from doing any of the following;",
+                        "parts": [
+                          {
+                            "id": "ac-3.3_smt.b.1",
+                            "name": "item",
+                            "props": [
+                              {
+                                "name": "label",
+                                "value": "(1)"
+                              }
+                            ],
+                            "prose": "Passing the information to unauthorized subjects or objects;"
+                          },
+                          {
+                            "id": "ac-3.3_smt.b.2",
+                            "name": "item",
+                            "props": [
+                              {
+                                "name": "label",
+                                "value": "(2)"
+                              }
+                            ],
+                            "prose": "Granting its privileges to other subjects;"
+                          },
+                          {
+                            "id": "ac-3.3_smt.b.3",
+                            "name": "item",
+                            "props": [
+                              {
+                                "name": "label",
+                                "value": "(3)"
+                              }
+                            ],
+                            "prose": "Changing one or more security attributes (specified by the policy) on subjects, objects, the system, or system components;"
+                          },
+                          {
+                            "id": "ac-3.3_smt.b.4",
+                            "name": "item",
+                            "props": [
+                              {
+                                "name": "label",
+                                "value": "(4)"
+                              }
+                            ],
+                            "prose": "Choosing the security attributes and attribute values (specified by the policy) to be associated with newly created or modified objects; and"
+                          },
+                          {
+                            "id": "ac-3.3_smt.b.5",
+                            "name": "item",
+                            "props": [
+                              {
+                                "name": "label",
+                                "value": "(5)"
+                              }
+                            ],
+                            "prose": "Changing the rules governing access control; and"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "ac-3.3_smt.c",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(c)"
+                          }
+                        ],
+                        "prose": "Specifies that {{ insert: param, ac-3.3_prm_2 }} may explicitly be granted {{ insert: param, ac-3.3_prm_3 }} such that they are not limited by any defined subset (or all) of the above constraints."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-3.3_gdn",
+                    "name": "guidance",
+                    "prose": "Mandatory access control is a type of nondiscretionary access control. Mandatory access control policies constrain what actions subjects can take with information obtained from objects for which they have already been granted access. This prevents the subjects from passing the information to unauthorized subjects and objects. Mandatory access control policies constrain actions that subjects can take with respect to the propagation of access control privileges; that is, a subject with a privilege cannot pass that privilege to other subjects. The policy is uniformly enforced over all subjects and objects to which the system has control. Otherwise, the access control policy can be circumvented. This enforcement is provided by an implementation that meets the reference monitor concept as described in [AC-25](#ac-25). The policy is bounded by the system (i.e., once the information is passed outside of the control of the system, additional means may be required to ensure that the constraints on the information remain in effect).\n\nThe trusted subjects described above are granted privileges consistent with the concept of least privilege (see [AC-6](#ac-6)). Trusted subjects are only given the minimum privileges necessary for satisfying organizational mission/business needs relative to the above policy. The control is most applicable when there is a mandate that establishes a policy regarding access to controlled unclassified information or classified information and some users of the system are not authorized access to all such information resident in the system. Mandatory access control can operate in conjunction with discretionary access control as described in [AC-3(4)](#ac-3.4). A subject constrained in its operation by mandatory access control policies can still operate under the less rigorous constraints of AC-3(4), but mandatory access control policies take precedence over the less rigorous constraints of AC-3(4). For example, while a mandatory access control policy imposes a constraint that prevents a subject from passing information to another subject operating at a different impact or classification level, AC-3(4) permits the subject to pass the information to any other subject with the same impact or classification level as the subject. Examples of mandatory access control policies include the Bell-LaPadula policy to protect confidentiality of information and the Biba policy to protect the integrity of information."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.4",
+                "class": "SP800-53-enhancement",
+                "title": "Discretionary Access Control",
+                "params": [
+                  {
+                    "id": "ac-3.4_prm_1",
+                    "label": "organization-defined discretionary access control policy"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(4)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.04"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.4_smt",
+                    "name": "statement",
+                    "prose": "Enforce {{ insert: param, ac-3.4_prm_1 }} over the set of covered subjects and objects specified in the policy, and where the policy specifies that a subject that has been granted access to information can do one or more of the following:",
+                    "parts": [
+                      {
+                        "id": "ac-3.4_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Pass the information to any other subjects or objects;"
+                      },
+                      {
+                        "id": "ac-3.4_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Grant its privileges to other subjects;"
+                      },
+                      {
+                        "id": "ac-3.4_smt.c",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(c)"
+                          }
+                        ],
+                        "prose": "Change security attributes on subjects, objects, the system, or the system’s components;"
+                      },
+                      {
+                        "id": "ac-3.4_smt.d",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(d)"
+                          }
+                        ],
+                        "prose": "Choose the security attributes to be associated with newly created or revised objects; or"
+                      },
+                      {
+                        "id": "ac-3.4_smt.e",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(e)"
+                          }
+                        ],
+                        "prose": "Change the rules governing access control."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-3.4_gdn",
+                    "name": "guidance",
+                    "prose": "When discretionary access control policies are implemented, subjects are not constrained with regard to what actions they can take with information for which they have already been granted access. Thus, subjects that have been granted access to information are not prevented from passing the information to other subjects or objects (i.e., subjects have the discretion to pass). Discretionary access control can operate in conjunction with mandatory access control as described in [AC-3(3)](#ac-3.3) and [AC-3(15)](#ac-3.15). A subject that is constrained in its operation by mandatory access control policies can still operate under the less rigorous constraints of discretionary access control. Therefore, while [AC-3(3)](#ac-3.3) imposes constraints that prevent a subject from passing information to another subject operating at a different impact or classification level, [AC-3(4)](#ac-3.4) permits the subject to pass the information to any subject at the same impact or classification level. The policy is bounded by the system. Once the information is passed outside of system control, additional means may be required to ensure that the constraints remain in effect. While traditional definitions of discretionary access control require identity-based access control, that limitation is not required for this particular use of discretionary access control."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.5",
+                "class": "SP800-53-enhancement",
+                "title": "Security-relevant Information",
+                "params": [
+                  {
+                    "id": "ac-3.5_prm_1",
+                    "label": "organization-defined security-relevant information"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(5)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.05"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#cm-6",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#sc-39",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.5_smt",
+                    "name": "statement",
+                    "prose": "Prevent access to {{ insert: param, ac-3.5_prm_1 }} except during secure, non-operable system states."
+                  },
+                  {
+                    "id": "ac-3.5_gdn",
+                    "name": "guidance",
+                    "prose": "Security-relevant information is information within systems that can potentially impact the operation of security functions or the provision of security services in a manner that could result in failure to enforce system security and privacy policies or maintain the separation of code and data. Security-relevant information includes access control lists, filtering rules for routers or firewalls, configuration parameters for security services, and cryptographic key management information. Secure, non-operable system states include the times in which systems are not performing mission or business-related processing, such as when the system is offline for maintenance, boot-up, troubleshooting, or shut down."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.6",
+                "class": "SP800-53-enhancement",
+                "title": "Protection of User and System Information",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(6)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.06"
+                  },
+                  {
+                    "name": "status",
+                    "value": "withdrawn"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#mp-4",
+                    "rel": "incorporated-into"
+                  },
+                  {
+                    "href": "#sc-28",
+                    "rel": "incorporated-into"
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.7",
+                "class": "SP800-53-enhancement",
+                "title": "Role-based Access Control",
+                "params": [
+                  {
+                    "id": "ac-3.7_prm_1",
+                    "label": "organization-defined roles and users authorized to assume such roles"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(7)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.07"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.7_smt",
+                    "name": "statement",
+                    "prose": "Enforce a role-based access control policy over defined subjects and objects and control access based upon {{ insert: param, ac-3.7_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-3.7_gdn",
+                    "name": "guidance",
+                    "prose": "Role-based access control (RBAC) is an access control policy that enforces access to objects and system functions based on the defined role (i.e., job function) of the subject. Organizations can create specific roles based on job functions and the authorizations (i.e., privileges) to perform needed operations on the systems associated with the organization-defined roles. When users are assigned to specific roles, they inherit the authorizations or privileges defined for those roles. RBAC simplifies privilege administration for organizations because privileges are not assigned directly to every user (which can be a large number of individuals) but are instead acquired through role assignments. RBAC can also increase privacy and security risk if individuals assigned to a role are given access to information beyond what they need to support organizational missions or business functions. RBAC can be implemented as a mandatory or discretionary form of access control. For organizations implementing RBAC with mandatory access controls, the requirements in [AC-3(3)](#ac-3.3) define the scope of the subjects and objects covered by the policy."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.8",
+                "class": "SP800-53-enhancement",
+                "title": "Revocation of Access Authorizations",
+                "params": [
+                  {
+                    "id": "ac-3.8_prm_1",
+                    "label": "organization-defined rules governing the timing of revocations of access authorizations"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(8)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.08"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.8_smt",
+                    "name": "statement",
+                    "prose": "Enforce the revocation of access authorizations resulting from changes to the security attributes of subjects and objects based on {{ insert: param, ac-3.8_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-3.8_gdn",
+                    "name": "guidance",
+                    "prose": "Revocation of access rules may differ based on the types of access revoked. For example, if a subject (i.e., user or process acting on behalf of a user) is removed from a group, access may not be revoked until the next time the object is opened or the next time the subject attempts to access the object. Revocation based on changes to security labels may take effect immediately. Organizations provide alternative approaches on how to make revocations immediate if systems cannot provide such capability and immediate revocation is necessary."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.9",
+                "class": "SP800-53-enhancement",
+                "title": "Controlled Release",
+                "params": [
+                  {
+                    "id": "ac-3.9_prm_1",
+                    "label": "organization-defined system or system component"
+                  },
+                  {
+                    "id": "ac-3.9_prm_2",
+                    "label": "organization-defined controls"
+                  },
+                  {
+                    "id": "ac-3.9_prm_3",
+                    "label": "organization-defined controls"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(9)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.09"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ca-3",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#pt-7",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#pt-8",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#sa-9",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#sc-16",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.9_smt",
+                    "name": "statement",
+                    "prose": "Release information outside of the system only if:",
+                    "parts": [
+                      {
+                        "id": "ac-3.9_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "The receiving {{ insert: param, ac-3.9_prm_1 }} provides {{ insert: param, ac-3.9_prm_2 }}; and"
+                      },
+                      {
+                        "id": "ac-3.9_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": " {{ insert: param, ac-3.9_prm_3 }} are used to validate the appropriateness of the information designated for release."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-3.9_gdn",
+                    "name": "guidance",
+                    "prose": "Organizations can only directly protect information when it resides within the system. Additional controls may be needed to ensure that organizational information is adequately protected once it is transmitted outside of the system. In situations where the system is unable to determine the adequacy of the protections provided by external entities, as a mitigation measure, organizations procedurally determine whether the external systems are providing adequate controls. The means used to determine the adequacy of controls provided by external systems include conducting periodic assessments (inspections/tests), establishing agreements between the organization and its counterpart organizations, or some other process. The means used by external entities to protect the information received need not be the same as those used by the organization, but the means employed are sufficient to provide consistent adjudication of the security and privacy policy to protect the information and individuals’ privacy.\n\nControlled release of information requires systems to implement technical or procedural means to validate the information prior to releasing it to external systems. For example, if the system passes information to a system controlled by another organization, technical means are employed to validate that the security and privacy attributes associated with the exported information are appropriate for the receiving system. Alternatively, if the system passes information to a printer in organization-controlled space, procedural means can be employed to ensure that only authorized individuals gain access to the printer."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.10",
+                "class": "SP800-53-enhancement",
+                "title": "Audited Override of Access Control Mechanisms",
+                "params": [
+                  {
+                    "id": "ac-3.10_prm_1",
+                    "label": "organization-defined conditions"
+                  },
+                  {
+                    "id": "ac-3.10_prm_2",
+                    "label": "organization-defined roles"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(10)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.10"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#au-2",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-6",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-10",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-12",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-14",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.10_smt",
+                    "name": "statement",
+                    "prose": "Employ an audited override of automated access control mechanisms under {{ insert: param, ac-3.10_prm_1 }} by {{ insert: param, ac-3.10_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-3.10_gdn",
+                    "name": "guidance",
+                    "prose": "In certain situations, such as when there is a threat to human life or an event that threatens the organization’s ability to carry out critical missions or business functions, an override capability for access control mechanisms may be needed. Override conditions are defined by organizations and used only in those limited circumstances. Audit events are defined in [AU-2](#au-2). Audit records are generated in [AU-12](#au-12)."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.11",
+                "class": "SP800-53-enhancement",
+                "title": "Restrict Access to Specific Information Types",
+                "params": [
+                  {
+                    "id": "ac-3.11_prm_1",
+                    "label": "organization-defined information types"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(11)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.11"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#cm-8",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#cm-12",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#cm-13",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#pm-5",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.11_smt",
+                    "name": "statement",
+                    "prose": "Restrict access to data repositories containing {{ insert: param, ac-3.11_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-3.11_gdn",
+                    "name": "guidance",
+                    "prose": "Restricting access to specific information is intended to provide flexibility regarding access control of specific information types within a system. For example, role-based access could be employed to allow access to only a specific type of personally identifiable information within a database rather than allowing access to the database in its entirety. Other examples include restricting access to cryptographic keys, authentication information, and selected system information."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.12",
+                "class": "SP800-53-enhancement",
+                "title": "Assert and Enforce Application Access",
+                "params": [
+                  {
+                    "id": "ac-3.12_prm_1",
+                    "label": "organization-defined system applications and functions"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(12)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.12"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#cm-7",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.12_smt",
+                    "name": "statement",
+                    "parts": [
+                      {
+                        "id": "ac-3.12_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Require applications to assert, as part of the installation process, the access needed to the following system applications and functions: {{ insert: param, ac-3.12_prm_1 }};"
+                      },
+                      {
+                        "id": "ac-3.12_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Provide an enforcement mechanism to prevent unauthorized access; and"
+                      },
+                      {
+                        "id": "ac-3.12_smt.c",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(c)"
+                          }
+                        ],
+                        "prose": "Approve access changes after initial installation of the application."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-3.12_gdn",
+                    "name": "guidance",
+                    "prose": "Asserting and enforcing application access is intended to address applications that need to access existing system applications and functions, including user contacts, global positioning systems, cameras, keyboards, microphones, networks, phones, or other files."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.13",
+                "class": "SP800-53-enhancement",
+                "title": "Attribute-based Access Control",
+                "params": [
+                  {
+                    "id": "ac-3.13_prm_1",
+                    "label": "organization-defined attributes to assume access permissions"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(13)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.13"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.13_smt",
+                    "name": "statement",
+                    "prose": "Enforce attribute-based access control policy over defined subjects and objects and control access based upon {{ insert: param, ac-3.13_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-3.13_gdn",
+                    "name": "guidance",
+                    "prose": "Attribute-based access control is an access control policy that restricts system access to authorized users based on specified organizational attributes (e.g., job function, identity), action attributes (e.g., read, write, delete), environmental attributes (e.g., time of day, location), and resource attributes (e.g., classification of a document). Organizations can create rules based on attributes and the authorizations (i.e., privileges) to perform needed operations on the systems associated with organization-defined attributes and rules. When users are assigned to attributes defined in attribute-based access control policies or rules, they can be provisioned to a system with the appropriate privileges or dynamically granted access to a protected resource. Attribute-based access control can be implemented as either a mandatory or discretionary form of access control. When implemented with mandatory access controls, the requirements in [AC-3(3)](#ac-3.3) define the scope of the subjects and objects covered by the policy."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.14",
+                "class": "SP800-53-enhancement",
+                "title": "Individual Access",
+                "params": [
+                  {
+                    "id": "ac-3.14_prm_1",
+                    "label": "organization-defined mechanisms"
+                  },
+                  {
+                    "id": "ac-3.14_prm_2",
+                    "label": "organization-defined elements"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(14)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.14"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ia-8",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#pm-22",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#pm-20",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#pm-21",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#pt-6",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.14_smt",
+                    "name": "statement",
+                    "prose": "Provide {{ insert: param, ac-3.14_prm_1 }} to enable individuals to have access to the following elements of their personally identifiable information: {{ insert: param, ac-3.14_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-3.14_gdn",
+                    "name": "guidance",
+                    "prose": "Individual access affords individuals the ability to review personally identifiable information about them held within organizational records, regardless of format. Access helps individuals to develop an understanding about how their personally identifiable information is being processed. It can also help individuals ensure that their data is accurate. Access mechanisms can include request forms and application interfaces. For federal agencies, [PRIVACT](#18e71fec-c6fd-475a-925a-5d8495cf8455) processes can be located in systems of record notices and on agency websites. Access to certain types of records may not be appropriate (e.g., for federal agencies, law enforcement records within a system of records may be exempt from disclosure under the [PRIVACT](#18e71fec-c6fd-475a-925a-5d8495cf8455)) or may require certain levels of authentication assurance. Organizational personnel consult with the senior agency official for privacy and legal counsel to determine appropriate mechanisms and access rights or limitations."
+                  }
+                ]
+              },
+              {
+                "id": "ac-3.15",
+                "class": "SP800-53-enhancement",
+                "title": "Discretionary and Mandatory Access Control",
+                "params": [
+                  {
+                    "id": "ac-3.15_prm_1",
+                    "label": "organization-defined mandatory access control policy"
+                  },
+                  {
+                    "id": "ac-3.15_prm_2",
+                    "label": "organization-defined discretionary access control policy"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-3(15)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-03.15"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-3",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#sc-2",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#sc-3",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ac-4",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-3.15_smt",
+                    "name": "statement",
+                    "parts": [
+                      {
+                        "id": "ac-3.15_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Enforce {{ insert: param, ac-3.15_prm_1 }} over the set of covered subjects and objects specified in the policy; and"
+                      },
+                      {
+                        "id": "ac-3.15_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Enforce {{ insert: param, ac-3.15_prm_2 }} over the set of covered subjects and objects specified in the policy."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-3.15_gdn",
+                    "name": "guidance",
+                    "prose": "Simultaneously implementing a mandatory access control policy and a discretionary access control policy can provide additional protection against the unauthorized execution of code by users or processes acting on behalf of users. This helps prevent a single compromised user or process from compromising the entire system."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ac-4",
+            "class": "SP800-53",
+            "title": "Information Flow Enforcement",
+            "params": [
+              {
+                "id": "ac-4_prm_1",
+                "label": "organization-defined information flow control policies"
+              }
+            ],
+            "props": [
+              {
+                "name": "label",
+                "value": "AC-4"
+              },
+              {
+                "name": "sort-id",
+                "value": "ac-04"
+              }
+            ],
+            "links": [
+              {
+                "href": "#e3cc0520-a366-4fc9-abc2-5272db7e3564",
+                "rel": "reference"
+              },
+              {
+                "href": "#2956e175-f674-43f4-b1b9-e074ad9fc39c",
+                "rel": "reference"
+              },
+              {
+                "href": "#388a3aa2-5d85-4bad-b8a3-77db80d63c4f",
+                "rel": "reference"
+              },
+              {
+                "href": "#a2590922-82f3-4277-83c0-ca5bee06dba4",
+                "rel": "reference"
+              },
+              {
+                "href": "#ac-3",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-6",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-16",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-17",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-19",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-21",
+                "rel": "related"
+              },
+              {
+                "href": "#au-10",
+                "rel": "related"
+              },
+              {
+                "href": "#ca-3",
+                "rel": "related"
+              },
+              {
+                "href": "#ca-9",
+                "rel": "related"
+              },
+              {
+                "href": "#cm-7",
+                "rel": "related"
+              },
+              {
+                "href": "#pl-9",
+                "rel": "related"
+              },
+              {
+                "href": "#pm-24",
+                "rel": "related"
+              },
+              {
+                "href": "#sa-17",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-4",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-7",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-16",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-31",
+                "rel": "related"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ac-4_smt",
+                "name": "statement",
+                "prose": "Enforce approved authorizations for controlling the flow of information within the system and between connected systems based on {{ insert: param, ac-4_prm_1 }}."
+              },
+              {
+                "id": "ac-4_gdn",
+                "name": "guidance",
+                "prose": "Information flow control regulates where information can travel within a system and between systems (in contrast to who is allowed to access the information) and without regard to subsequent accesses to that information. Flow control restrictions include blocking external traffic that claims to be from within the organization, keeping export-controlled information from being transmitted in the clear to the Internet, restricting web requests that are not from the internal web proxy server, and limiting information transfers between organizations based on data structures and content. Transferring information between organizations may require an agreement specifying how the information flow is enforced (see [CA-3](#ca-3)). Transferring information between systems in different security or privacy domains with different security or privacy policies introduces the risk that such transfers violate one or more domain security or privacy policies. In such situations, information owners/stewards provide guidance at designated policy enforcement points between connected systems. Organizations consider mandating specific architectural solutions to enforce specific security and privacy policies. Enforcement includes prohibiting information transfers between connected systems (i.e., allowing access only), verifying write permissions before accepting information from another security or privacy domain or connected system, employing hardware mechanisms to enforce one-way information flows, and implementing trustworthy regrading mechanisms to reassign security or privacy attributes and labels.\n\nOrganizations commonly employ information flow control policies and enforcement mechanisms to control the flow of information between designated sources and destinations within systems and between connected systems. Flow control is based on the characteristics of the information and/or the information path. Enforcement occurs, for example, in boundary protection devices that employ rule sets or establish configuration settings that restrict system services, provide a packet-filtering capability based on header information, or provide a message-filtering capability based on message content. Organizations also consider the trustworthiness of filtering and/or inspection mechanisms (i.e., hardware, firmware, and software components) that are critical to information flow enforcement. Control enhancements 3 through 32 primarily address cross-domain solution needs that focus on more advanced filtering techniques, in-depth analysis, and stronger flow enforcement mechanisms implemented in cross-domain products, such as high-assurance guards. Such capabilities are generally not available in commercial off-the-shelf products. Information flow enforcement also applies to control plane traffic (e.g., routing and DNS)."
+              }
+            ],
+            "controls": [
+              {
+                "id": "ac-4.1",
+                "class": "SP800-53-enhancement",
+                "title": "Object Security and Privacy Attributes",
+                "params": [
+                  {
+                    "id": "ac-4.1_prm_1",
+                    "label": "organization-defined security and privacy attributes"
+                  },
+                  {
+                    "id": "ac-4.1_prm_2",
+                    "label": "organization-defined information, source, and destination objects"
+                  },
+                  {
+                    "id": "ac-4.1_prm_3",
+                    "label": "organization-defined information flow control policies"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(1)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.01"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.1_smt",
+                    "name": "statement",
+                    "prose": "Use {{ insert: param, ac-4.1_prm_1 }} associated with {{ insert: param, ac-4.1_prm_2 }} to enforce {{ insert: param, ac-4.1_prm_3 }} as a basis for flow control decisions."
+                  },
+                  {
+                    "id": "ac-4.1_gdn",
+                    "name": "guidance",
+                    "prose": "Information flow enforcement mechanisms compare security and privacy attributes associated with information (i.e., data content and structure) and source and destination objects and respond appropriately when the enforcement mechanisms encounter information flows not explicitly allowed by information flow policies. For example, an information object labeled Secret would be allowed to flow to a destination object labeled Secret, but an information object labeled Top Secret would not be allowed to flow to a destination object labeled Secret. A dataset of personally identifiable information may be tagged with restrictions against combining with other types of datasets and, thus, would not be allowed to flow to the restricted dataset. Security and privacy attributes can also include source and destination addresses employed in traffic filter firewalls. Flow enforcement using explicit security or privacy attributes can be used, for example, to control the release of certain types of information."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.2",
+                "class": "SP800-53-enhancement",
+                "title": "Processing Domains",
+                "params": [
+                  {
+                    "id": "ac-4.2_prm_1",
+                    "label": "organization-defined information flow control policies"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(2)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.02"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#sc-39",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.2_smt",
+                    "name": "statement",
+                    "prose": "Use protected processing domains to enforce {{ insert: param, ac-4.2_prm_1 }} as a basis for flow control decisions."
+                  },
+                  {
+                    "id": "ac-4.2_gdn",
+                    "name": "guidance",
+                    "prose": "Protected processing domains within systems are processing spaces that have controlled interactions with other processing spaces, enabling control of information flows between these spaces and to/from information objects. A protected processing domain can be provided, for example, by implementing domain and type enforcement. In domain and type enforcement, system processes are assigned to domains, information is identified by types, and information flows are controlled based on allowed information accesses (i.e., determined by domain and type), allowed signaling among domains, and allowed process transitions to other domains."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.3",
+                "class": "SP800-53-enhancement",
+                "title": "Dynamic Information Flow Control",
+                "params": [
+                  {
+                    "id": "ac-4.3_prm_1",
+                    "label": "organization-defined information flow control policies"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(3)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.03"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#si-4",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.3_smt",
+                    "name": "statement",
+                    "prose": "Enforce {{ insert: param, ac-4.3_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-4.3_gdn",
+                    "name": "guidance",
+                    "prose": "Organizational policies regarding dynamic information flow control include allowing or disallowing information flows based on changing conditions or mission or operational considerations. Changing conditions include changes in risk tolerance due to changes in the immediacy of mission or business needs, changes in the threat environment, and detection of potentially harmful or adverse events."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.4",
+                "class": "SP800-53-enhancement",
+                "title": "Flow Control of Encrypted Information",
+                "params": [
+                  {
+                    "id": "ac-4.4_prm_1",
+                    "label": "organization-defined information flow control mechanisms"
+                  },
+                  {
+                    "id": "ac-4.4_prm_2",
+                    "select": {
+                      "how-many": "one-or-more",
+                      "choice": [
+                        "decrypting the information",
+                        "blocking the flow of the encrypted information",
+                        "terminating communications sessions attempting to pass encrypted information",
+                        " {{ insert: param, ac-4.4_prm_3 }} "
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ac-4.4_prm_3",
+                    "depends-on": "ac-4.4_prm_2",
+                    "label": "organization-defined procedure or method",
+                    "values": ["my procedure"]
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(4)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.04"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#si-4",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.4_smt",
+                    "name": "statement",
+                    "prose": "Prevent encrypted information from bypassing {{ insert: param, ac-4.4_prm_1 }} by {{ insert: param, ac-4.4_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-4.4_gdn",
+                    "name": "guidance",
+                    "prose": "Flow control mechanisms include content checking, security policy filters, and data type identifiers. The term encryption is extended to cover encoded data not recognized by filtering mechanisms."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.5",
+                "class": "SP800-53-enhancement",
+                "title": "Embedded Data Types",
+                "params": [
+                  {
+                    "id": "ac-4.5_prm_1",
+                    "label": "organization-defined limitations"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(5)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.05"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.5_smt",
+                    "name": "statement",
+                    "prose": "Enforce {{ insert: param, ac-4.5_prm_1 }} on embedding data types within other data types."
+                  },
+                  {
+                    "id": "ac-4.5_gdn",
+                    "name": "guidance",
+                    "prose": "Embedding data types within other data types may result in reduced flow control effectiveness. Data type embedding includes inserting files as objects within other files and using compressed or archived data types that may include multiple embedded data types. Limitations on data type embedding consider the levels of embedding and prohibit levels of data type embedding that are beyond the capability of the inspection tools."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.6",
+                "class": "SP800-53-enhancement",
+                "title": "Metadata",
+                "params": [
+                  {
+                    "id": "ac-4.6_prm_1",
+                    "label": "organization-defined metadata"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(6)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.06"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ac-16",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#si-7",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.6_smt",
+                    "name": "statement",
+                    "prose": "Enforce information flow control based on {{ insert: param, ac-4.6_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-4.6_gdn",
+                    "name": "guidance",
+                    "prose": "Metadata is information that describes the characteristics of data. Metadata can include structural metadata describing data structures or descriptive metadata describing data content. Enforcement of allowed information flows based on metadata enables simpler and more effective flow control. Organizations consider the trustworthiness of metadata regarding data accuracy (i.e., knowledge that the metadata values are correct with respect to the data), data integrity (i.e., protecting against unauthorized changes to metadata tags), and the binding of metadata to the data payload (i.e., employing sufficiently strong binding techniques with appropriate assurance)."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.7",
+                "class": "SP800-53-enhancement",
+                "title": "One-way Flow Mechanisms",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(7)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.07"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.7_smt",
+                    "name": "statement",
+                    "prose": "Enforce one-way information flows through hardware-based flow control mechanisms."
+                  },
+                  {
+                    "id": "ac-4.7_gdn",
+                    "name": "guidance",
+                    "prose": "One-way flow mechanisms may also be referred to as a unidirectional network, unidirectional security gateway, or data diode. One-way flow mechanisms can be used to prevent data from being exported from a higher impact or classified domain or system while permitting data from a lower impact or unclassified domain or system to be imported."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.8",
+                "class": "SP800-53-enhancement",
+                "title": "Security and Privacy Policy Filters",
+                "params": [
+                  {
+                    "id": "ac-4.8_prm_1",
+                    "label": "organization-defined security or privacy policy filters"
+                  },
+                  {
+                    "id": "ac-4.8_prm_2",
+                    "label": "organization-defined information flows"
+                  },
+                  {
+                    "id": "ac-4.8_prm_3",
+                    "select": {
+                      "how-many": "one-or-more",
+                      "choice": [
+                        "Block",
+                        "Strip",
+                        "Modify",
+                        "Quarantine"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ac-4.8_prm_4",
+                    "label": "organization-defined security or privacy policy"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(8)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.08"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.8_smt",
+                    "name": "statement",
+                    "parts": [
+                      {
+                        "id": "ac-4.8_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Enforce information flow control using {{ insert: param, ac-4.8_prm_1 }} as a basis for flow control decisions for {{ insert: param, ac-4.8_prm_2 }}; and"
+                      },
+                      {
+                        "id": "ac-4.8_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": " {{ insert: param, ac-4.8_prm_3 }} data after a filter processing failure in accordance with {{ insert: param, ac-4.8_prm_4 }}."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-4.8_gdn",
+                    "name": "guidance",
+                    "prose": "Organization-defined security or privacy policy filters can address data structures and content. For example, security or privacy policy filters for data structures can check for maximum file lengths, maximum field sizes, and data/file types (for structured and unstructured data). Security or privacy policy filters for data content can check for specific words, enumerated values or data value ranges, and hidden content. Structured data permits the interpretation of data content by applications. Unstructured data refers to digital information without a data structure or with a data structure that does not facilitate the development of rule sets to address the impact or classification level of the information conveyed by the data or the flow enforcement decisions. Unstructured data consists of bitmap objects that are inherently non-language-based (i.e., image, video, or audio files) and textual objects that are based on written or printed languages. Organizations can implement more than one security or privacy policy filter to meet information flow control objectives."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.9",
+                "class": "SP800-53-enhancement",
+                "title": "Human Reviews",
+                "params": [
+                  {
+                    "id": "ac-4.9_prm_1",
+                    "label": "organization-defined information flows"
+                  },
+                  {
+                    "id": "ac-4.9_prm_2",
+                    "label": "organization-defined conditions"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(9)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.09"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.9_smt",
+                    "name": "statement",
+                    "prose": "Enforce the use of human reviews for {{ insert: param, ac-4.9_prm_1 }} under the following conditions: {{ insert: param, ac-4.9_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-4.9_gdn",
+                    "name": "guidance",
+                    "prose": "Organizations define security or privacy policy filters for all situations where automated flow control decisions are possible. When a fully automated flow control decision is not possible, then a human review may be employed in lieu of or as a complement to automated security or privacy policy filtering. Human reviews may also be employed as deemed necessary by organizations."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.10",
+                "class": "SP800-53-enhancement",
+                "title": "Enable and Disable Security or Privacy Policy Filters",
+                "params": [
+                  {
+                    "id": "ac-4.10_prm_1",
+                    "label": "organization-defined security or privacy policy filters"
+                  },
+                  {
+                    "id": "ac-4.10_prm_2",
+                    "label": "organization-defined conditions"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(10)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.10"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.10_smt",
+                    "name": "statement",
+                    "prose": "Provide the capability for privileged administrators to enable and disable {{ insert: param, ac-4.10_prm_1 }} under the following conditions: {{ insert: param, ac-4.10_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-4.10_gdn",
+                    "name": "guidance",
+                    "prose": "For example, as allowed by the system authorization, administrators can enable security or privacy policy filters to accommodate approved data types. Administrators also have the capability to select the filters that are executed on a specific data flow based on the type of data that is being transferred, the source and destination security domains, and other security or privacy relevant features, as needed."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.11",
+                "class": "SP800-53-enhancement",
+                "title": "Configuration of Security or Privacy Policy Filters",
+                "params": [
+                  {
+                    "id": "ac-4.11_prm_1",
+                    "label": "organization-defined security or privacy policy filters"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(11)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.11"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.11_smt",
+                    "name": "statement",
+                    "prose": "Provide the capability for privileged administrators to configure {{ insert: param, ac-4.11_prm_1 }} to support different security or privacy policies."
+                  },
+                  {
+                    "id": "ac-4.11_gdn",
+                    "name": "guidance",
+                    "prose": "Documentation contains detailed information for configuring security or privacy policy filters. For example, administrators can configure security or privacy policy filters to include the list of inappropriate words that security or privacy policy mechanisms check in accordance with the definitions provided by organizations."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.12",
+                "class": "SP800-53-enhancement",
+                "title": "Data Type Identifiers",
+                "params": [
+                  {
+                    "id": "ac-4.12_prm_1",
+                    "label": "organization-defined data type identifiers"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(12)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.12"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.12_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, use {{ insert: param, ac-4.12_prm_1 }} to validate data essential for information flow decisions."
+                  },
+                  {
+                    "id": "ac-4.12_gdn",
+                    "name": "guidance",
+                    "prose": "Data type identifiers include filenames, file types, file signatures or tokens, and multiple internal file signatures or tokens. Systems only allow transfer of data that is compliant with data type format specifications. Identification and validation of data types is based on defined specifications associated with each allowed data format. The filename and number alone are not used for data type identification. Content is validated syntactically and semantically against its specification to ensure that it is the proper data type."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.13",
+                "class": "SP800-53-enhancement",
+                "title": "Decomposition into Policy-relevant Subcomponents",
+                "params": [
+                  {
+                    "id": "ac-4.13_prm_1",
+                    "label": "organization-defined policy-relevant subcomponents"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(13)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.13"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.13_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, decompose information into {{ insert: param, ac-4.13_prm_1 }} for submission to policy enforcement mechanisms."
+                  },
+                  {
+                    "id": "ac-4.13_gdn",
+                    "name": "guidance",
+                    "prose": "Decomposing information into policy-relevant subcomponents prior to information transfer facilitates policy decisions on source, destination, certificates, classification, attachments, and other security- or privacy-related component differentiators. Policy enforcement mechanisms apply filtering, inspection, and/or sanitization rules to the policy-relevant subcomponents of information to facilitate flow enforcement prior to transferring such information to different security domains."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.14",
+                "class": "SP800-53-enhancement",
+                "title": "Security or Privacy Policy Filter Constraints",
+                "params": [
+                  {
+                    "id": "ac-4.14_prm_1",
+                    "label": "organization-defined security or privacy policy filters"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(14)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.14"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.14_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, implement {{ insert: param, ac-4.14_prm_1 }} requiring fully enumerated formats that restrict data structure and content."
+                  },
+                  {
+                    "id": "ac-4.14_gdn",
+                    "name": "guidance",
+                    "prose": "Data structure and content restrictions reduce the range of potential malicious or unsanctioned content in cross-domain transactions. Security or privacy policy filters that restrict data structures include restricting file sizes and field lengths. Data content policy filters include encoding formats for character sets, restricting character data fields to only contain alpha-numeric characters, prohibiting special characters, and validating schema structures."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.15",
+                "class": "SP800-53-enhancement",
+                "title": "Detection of Unsanctioned Information",
+                "params": [
+                  {
+                    "id": "ac-4.15_prm_1",
+                    "label": "organization-defined unsanctioned information"
+                  },
+                  {
+                    "id": "ac-4.15_prm_2",
+                    "label": "organization-defined security or privacy policy"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(15)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.15"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#si-3",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.15_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, examine the information for the presence of {{ insert: param, ac-4.15_prm_1 }} and prohibit the transfer of such information in accordance with the {{ insert: param, ac-4.15_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-4.15_gdn",
+                    "name": "guidance",
+                    "prose": "Unsanctioned information includes malicious code, information that is inappropriate for release from the source network, or executable code that could disrupt or harm the services or systems on the destination network."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.16",
+                "class": "SP800-53-enhancement",
+                "title": "Information Transfers on Interconnected Systems",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(16)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.16"
+                  },
+                  {
+                    "name": "status",
+                    "value": "withdrawn"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "incorporated-into"
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.17",
+                "class": "SP800-53-enhancement",
+                "title": "Domain Authentication",
+                "params": [
+                  {
+                    "id": "ac-4.17_prm_1",
+                    "select": {
+                      "how-many": "one-or-more",
+                      "choice": [
+                        "organization",
+                        "system",
+                        "application",
+                        "service",
+                        "individual"
+                      ]
+                    }
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(17)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.17"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ia-2",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ia-3",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ia-9",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.17_smt",
+                    "name": "statement",
+                    "prose": "Uniquely identify and authenticate source and destination points by {{ insert: param, ac-4.17_prm_1 }} for information transfer."
+                  },
+                  {
+                    "id": "ac-4.17_gdn",
+                    "name": "guidance",
+                    "prose": "Attribution is a critical component of a security and privacy concept of operations. The ability to identify source and destination points for information flowing within systems allows the forensic reconstruction of events and encourages policy compliance by attributing policy violations to specific organizations or individuals. Successful domain authentication requires that system labels distinguish among systems, organizations, and individuals involved in preparing, sending, receiving, or disseminating information. Attribution also allows organizations to better maintain the lineage of personally identifiable information processing as it flows through systems and can facilitate consent tracking, as well as correction, deletion, or access requests from individuals."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.18",
+                "class": "SP800-53-enhancement",
+                "title": "Security Attribute Binding",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(18)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.18"
+                  },
+                  {
+                    "name": "status",
+                    "value": "withdrawn"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-16",
+                    "rel": "incorporated-into"
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.19",
+                "class": "SP800-53-enhancement",
+                "title": "Validation of Metadata",
+                "params": [
+                  {
+                    "id": "ac-4.19_prm_1",
+                    "label": "organization-defined security or privacy policy filters"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(19)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.19"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.19_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, implement {{ insert: param, ac-4.19_prm_1 }} on metadata."
+                  },
+                  {
+                    "id": "ac-4.19_gdn",
+                    "name": "guidance",
+                    "prose": "All information (including metadata and the data to which the metadata applies) is subject to filtering and inspection. Some organizations distinguish between metadata and data payloads (i.e., only the data to which the metadata is bound). Other organizations do not make such distinctions and consider metadata and the data to which the metadata applies to be part of the payload."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.20",
+                "class": "SP800-53-enhancement",
+                "title": "Approved Solutions",
+                "params": [
+                  {
+                    "id": "ac-4.20_prm_1",
+                    "label": "organization-defined solutions in approved configurations"
+                  },
+                  {
+                    "id": "ac-4.20_prm_2",
+                    "label": "organization-defined information"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(20)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.20"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.20_smt",
+                    "name": "statement",
+                    "prose": "Employ {{ insert: param, ac-4.20_prm_1 }} to control the flow of {{ insert: param, ac-4.20_prm_2 }} across security domains."
+                  },
+                  {
+                    "id": "ac-4.20_gdn",
+                    "name": "guidance",
+                    "prose": "Organizations define approved solutions and configurations in cross-domain policies and guidance in accordance with the types of information flows across classification boundaries. The National Security Agency (NSA) National Cross Domain Strategy and Management Office provides a listing of approved cross-domain solutions. Contact [ncdsmo@nsa.gov](mailto:ncdsmo@nsa.gov) for more information."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.21",
+                "class": "SP800-53-enhancement",
+                "title": "Physical or Logical Separation of Information Flows",
+                "params": [
+                  {
+                    "id": "ac-4.21_prm_1",
+                    "label": "organization-defined mechanisms and/or techniques"
+                  },
+                  {
+                    "id": "ac-4.21_prm_2",
+                    "label": "organization-defined required separations by types of information"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(21)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.21"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#sc-32",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.21_smt",
+                    "name": "statement",
+                    "prose": "Separate information flows logically or physically using {{ insert: param, ac-4.21_prm_1 }} to accomplish {{ insert: param, ac-4.21_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-4.21_gdn",
+                    "name": "guidance",
+                    "prose": "Enforcing the separation of information flows associated with defined types of data can enhance protection by ensuring that information is not commingled while in transit and by enabling flow control by transmission paths that are not otherwise achievable. Types of separable information include inbound and outbound communications traffic, service requests and responses, and information of differing security impact or classification levels."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.22",
+                "class": "SP800-53-enhancement",
+                "title": "Access Only",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(22)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.22"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.22_smt",
+                    "name": "statement",
+                    "prose": "Provide access from a single device to computing platforms, applications, or data residing in multiple different security domains, while preventing information flow between the different security domains."
+                  },
+                  {
+                    "id": "ac-4.22_gdn",
+                    "name": "guidance",
+                    "prose": "The system provides a capability for users to access each connected security domain without providing any mechanisms to allow users to transfer data or information between the different security domains. An example of an access-only solution is a terminal that provides a user access to information with different security classifications while assuredly keeping the information separate."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.23",
+                "class": "SP800-53-enhancement",
+                "title": "Modify Non-releasable Information",
+                "params": [
+                  {
+                    "id": "ac-4.23_prm_1",
+                    "label": "organization-defined modification action"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(23)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.23"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.23_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, modify non-releasable information by implementing {{ insert: param, ac-4.23_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-4.23_gdn",
+                    "name": "guidance",
+                    "prose": "Modifying non-releasable information can help prevent a data spill or attack when information is transferred across security domains. Modification actions include masking, permutation, alteration, removal, or redaction."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.24",
+                "class": "SP800-53-enhancement",
+                "title": "Internal Normalized Format",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(24)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.24"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.24_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, parse incoming data into an internal normalized format and regenerate the data to be consistent with its intended specification."
+                  },
+                  {
+                    "id": "ac-4.24_gdn",
+                    "name": "guidance",
+                    "prose": "Converting data into normalized forms is one of most of effective mechanisms to stop malicious attacks and large classes of data exfiltration."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.25",
+                "class": "SP800-53-enhancement",
+                "title": "Data Sanitization",
+                "params": [
+                  {
+                    "id": "ac-4.25_prm_1",
+                    "select": {
+                      "how-many": "one-or-more",
+                      "choice": [
+                        "delivery of malicious content, command and control of malicious code, malicious code augmentation, and steganography encoded data",
+                        "spillage of sensitive information"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "ac-4.25_prm_2",
+                    "label": "organization-defined policy"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(25)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.25"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#mp-6",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.25_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, sanitize data to minimize {{ insert: param, ac-4.25_prm_1 }} in accordance with {{ insert: param, ac-4.25_prm_2 }}."
+                  },
+                  {
+                    "id": "ac-4.25_gdn",
+                    "name": "guidance",
+                    "prose": "Data sanitization is the process of irreversibly removing or destroying data stored on a memory device (e.g., hard drives, flash memory/solid state drives, mobile devices, CDs, and DVDs) or in hard copy form."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.26",
+                "class": "SP800-53-enhancement",
+                "title": "Audit Filtering Actions",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(26)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.26"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#au-2",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-3",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-12",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.26_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, record and audit content filtering actions and results for the information being filtered."
+                  },
+                  {
+                    "id": "ac-4.26_gdn",
+                    "name": "guidance",
+                    "prose": "Content filtering is the process of inspecting information as it traverses a cross-domain solution and determines if the information meets a predefined policy. Content filtering actions and the results of filtering actions are recorded for individual messages to ensure that the correct filter actions were applied. Content filter reports are used to assist in troubleshooting actions by, for example, determining why message content was modified and/or why it failed the filtering process. Audit events are defined in [AU-2](#au-2). Audit records are generated in [AU-12](#au-12)."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.27",
+                "class": "SP800-53-enhancement",
+                "title": "Redundant/independent Filtering Mechanisms",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(27)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.27"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.27_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, implement content filtering solutions that provide redundant and independent filtering mechanisms for each data type."
+                  },
+                  {
+                    "id": "ac-4.27_gdn",
+                    "name": "guidance",
+                    "prose": "Content filtering is the process of inspecting information as it traverses a cross-domain solution and determines if the information meets a predefined policy. Redundant and independent content filtering eliminates a single point of failure filtering system. Independence is defined as the implementation of a content filter that uses a different code base and supporting libraries (e.g., two JPEG filters using different vendors’ JPEG libraries) and multiple, independent system processes."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.28",
+                "class": "SP800-53-enhancement",
+                "title": "Linear Filter Pipelines",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(28)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.28"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.28_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, implement a linear content filter pipeline that is enforced with discretionary and mandatory access controls."
+                  },
+                  {
+                    "id": "ac-4.28_gdn",
+                    "name": "guidance",
+                    "prose": "Content filtering is the process of inspecting information as it traverses a cross-domain solution and determines if the information meets a predefined policy. The use of linear content filter pipelines ensures that filter processes are non-bypassable and always invoked. In general, the use of parallel filtering architectures for content filtering of a single data type introduces bypass and non-invocation issues."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.29",
+                "class": "SP800-53-enhancement",
+                "title": "Filter Orchestration Engines",
+                "params": [
+                  {
+                    "id": "ac-4.29_prm_1",
+                    "label": "organization-defined policy"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(29)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.29"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.29_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, employ content filter orchestration engines to ensure that:",
+                    "parts": [
+                      {
+                        "id": "ac-4.29_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Content filtering mechanisms successfully complete execution without errors; and"
+                      },
+                      {
+                        "id": "ac-4.29_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Content filtering actions occur in the correct order and comply with {{ insert: param, ac-4.29_prm_1 }}."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-4.29_gdn",
+                    "name": "guidance",
+                    "prose": "Content filtering is the process of inspecting information as it traverses a cross-domain solution and determines if the information meets a predefined security policy. An orchestration engine coordinates the sequencing of activities (manual and automated) in a content filtering process. Errors are defined as either anomalous actions or unexpected termination of the content filter process. This is not the same as a filter failing content due to non-compliance with policy. Content filter reports are a commonly used mechanism to ensure that expected filtering actions are completed successfully."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.30",
+                "class": "SP800-53-enhancement",
+                "title": "Filter Mechanisms Using Multiple Processes",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(30)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.30"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.30_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, implement content filtering mechanisms using multiple processes."
+                  },
+                  {
+                    "id": "ac-4.30_gdn",
+                    "name": "guidance",
+                    "prose": "The use of multiple processes to implement content filtering mechanisms reduces the likelihood of a single point of failure."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.31",
+                "class": "SP800-53-enhancement",
+                "title": "Failed Content Transfer Prevention",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(31)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.31"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.31_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, prevent the transfer of failed content to the receiving domain."
+                  },
+                  {
+                    "id": "ac-4.31_gdn",
+                    "name": "guidance",
+                    "prose": "Content that failed filtering checks can corrupt the system if transferred to the receiving domain."
+                  }
+                ]
+              },
+              {
+                "id": "ac-4.32",
+                "class": "SP800-53-enhancement",
+                "title": "Process Requirements for Information Transfer",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-4(32)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-04.32"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-4",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-4.32_smt",
+                    "name": "statement",
+                    "prose": "When transferring information between different security domains, the process that transfers information between filter pipelines:",
+                    "parts": [
+                      {
+                        "id": "ac-4.32_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Does not filter message content;"
+                      },
+                      {
+                        "id": "ac-4.32_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Validates filtering metadata;"
+                      },
+                      {
+                        "id": "ac-4.32_smt.c",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(c)"
+                          }
+                        ],
+                        "prose": "Ensures the content associated with the filtering metadata has successfully completed filtering; and"
+                      },
+                      {
+                        "id": "ac-4.32_smt.d",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(d)"
+                          }
+                        ],
+                        "prose": "Transfers the content to the destination filter pipeline."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-4.32_gdn",
+                    "name": "guidance",
+                    "prose": "The processes transferring information between filter pipelines have minimum complexity and functionality to provide assurance that the processes operate correctly."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ac-5",
+            "class": "SP800-53",
+            "title": "Separation of Duties",
+            "params": [
+              {
+                "id": "ac-5_prm_1",
+                "label": "organization-defined duties of individuals requiring separation"
+              }
+            ],
+            "props": [
+              {
+                "name": "label",
+                "value": "AC-5"
+              },
+              {
+                "name": "sort-id",
+                "value": "ac-05"
+              }
+            ],
+            "links": [
+              {
+                "href": "#ac-2",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-3",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-6",
+                "rel": "related"
+              },
+              {
+                "href": "#au-9",
+                "rel": "related"
+              },
+              {
+                "href": "#cm-5",
+                "rel": "related"
+              },
+              {
+                "href": "#cm-11",
+                "rel": "related"
+              },
+              {
+                "href": "#cp-9",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-2",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-4",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-5",
+                "rel": "related"
+              },
+              {
+                "href": "#ia-12",
+                "rel": "related"
+              },
+              {
+                "href": "#ma-3",
+                "rel": "related"
+              },
+              {
+                "href": "#ma-5",
+                "rel": "related"
+              },
+              {
+                "href": "#ps-2",
+                "rel": "related"
+              },
+              {
+                "href": "#sa-8",
+                "rel": "related"
+              },
+              {
+                "href": "#sa-17",
+                "rel": "related"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ac-5_smt",
+                "name": "statement",
+                "parts": [
+                  {
+                    "id": "ac-5_smt.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "a."
+                      }
+                    ],
+                    "prose": "Identify and document {{ insert: param, ac-5_prm_1 }}; and"
+                  },
+                  {
+                    "id": "ac-5_smt.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "b."
+                      }
+                    ],
+                    "prose": "Define system access authorizations to support separation of duties."
+                  }
+                ]
+              },
+              {
+                "id": "ac-5_gdn",
+                "name": "guidance",
+                "prose": "Separation of duties addresses the potential for abuse of authorized privileges and helps to reduce the risk of malevolent activity without collusion. Separation of duties includes dividing mission or business functions and support functions among different individuals or roles, conducting system support functions with different individuals, and ensuring that security personnel who administer access control functions do not also administer audit functions. Because separation of duty violations can span systems and application domains, organizations consider the entirety of systems and system components when developing policy on separation of duties. Separation of duties is enforced through the account management activities in [AC-2](#ac-2), access control mechanisms in [AC-3](#ac-3), and identity management activities in [IA-2](#ia-2), [IA-4](#ia-4), and [IA-12](#ia-12)."
+              }
+            ]
+          },
+          {
+            "id": "ac-6",
+            "class": "SP800-53",
+            "title": "Least Privilege",
+            "props": [
+              {
+                "name": "label",
+                "value": "AC-6"
+              },
+              {
+                "name": "sort-id",
+                "value": "ac-06"
+              }
+            ],
+            "links": [
+              {
+                "href": "#ac-2",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-3",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-5",
+                "rel": "related"
+              },
+              {
+                "href": "#ac-16",
+                "rel": "related"
+              },
+              {
+                "href": "#cm-5",
+                "rel": "related"
+              },
+              {
+                "href": "#cm-11",
+                "rel": "related"
+              },
+              {
+                "href": "#pl-2",
+                "rel": "related"
+              },
+              {
+                "href": "#pm-12",
+                "rel": "related"
+              },
+              {
+                "href": "#sa-8",
+                "rel": "related"
+              },
+              {
+                "href": "#sa-15",
+                "rel": "related"
+              },
+              {
+                "href": "#sa-17",
+                "rel": "related"
+              },
+              {
+                "href": "#sc-38",
+                "rel": "related"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ac-6_smt",
+                "name": "statement",
+                "prose": "Employ the principle of least privilege, allowing only authorized accesses for users (or processes acting on behalf of users) that are necessary to accomplish assigned organizational tasks."
+              },
+              {
+                "id": "ac-6_gdn",
+                "name": "guidance",
+                "prose": "Organizations employ least privilege for specific duties and systems. The principle of least privilege is also applied to system processes, ensuring that the processes have access to systems and operate at privilege levels no higher than necessary to accomplish organizational missions or business functions. Organizations consider the creation of additional processes, roles, and accounts as necessary to achieve least privilege. Organizations apply least privilege to the development, implementation, and operation of organizational systems."
+              }
+            ],
+            "controls": [
+              {
+                "id": "ac-6.1",
+                "class": "SP800-53-enhancement",
+                "title": "Authorize Access to Security Functions",
+                "params": [
+                  {
+                    "id": "ac-6.1_prm_1",
+                    "label": "organization-defined individuals or roles"
+                  },
+                  {
+                    "id": "ac-6.1_prm_2",
+                    "label": "organization-defined security functions (deployed in hardware, software, and firmware)"
+                  },
+                  {
+                    "id": "ac-6.1_prm_3",
+                    "label": "organization-defined security-relevant information"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(1)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.01"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ac-17",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ac-18",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ac-19",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-9",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#pe-2",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.1_smt",
+                    "name": "statement",
+                    "prose": "Authorize access for {{ insert: param, ac-6.1_prm_1 }} to:",
+                    "parts": [
+                      {
+                        "id": "ac-6.1_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": " {{ insert: param, ac-6.1_prm_2 }}; and"
+                      },
+                      {
+                        "id": "ac-6.1_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": " {{ insert: param, ac-6.1_prm_3 }}."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-6.1_gdn",
+                    "name": "guidance",
+                    "prose": "Security functions include establishing system accounts, configuring access authorizations (i.e., permissions, privileges), configuring settings for events to be audited, and establishing intrusion detection parameters. Security-relevant information includes filtering rules for routers or firewalls, configuration parameters for security services, cryptographic key management information, and access control lists. Authorized personnel include security administrators, system administrators, system security officers, system programmers, and other privileged users."
+                  }
+                ]
+              },
+              {
+                "id": "ac-6.2",
+                "class": "SP800-53-enhancement",
+                "title": "Non-privileged Access for Nonsecurity Functions",
+                "params": [
+                  {
+                    "id": "ac-6.2_prm_1",
+                    "label": "organization-defined security functions or security-relevant information"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(2)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.02"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ac-17",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ac-18",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ac-19",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#pl-4",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.2_smt",
+                    "name": "statement",
+                    "prose": "Require that users of system accounts (or roles) with access to {{ insert: param, ac-6.2_prm_1 }} use non-privileged accounts or roles, when accessing nonsecurity functions."
+                  },
+                  {
+                    "id": "ac-6.2_gdn",
+                    "name": "guidance",
+                    "prose": "Requiring the use of non-privileged accounts when accessing nonsecurity functions limits exposure when operating from within privileged accounts or roles. The inclusion of roles addresses situations where organizations implement access control policies, such as role-based access control, and where a change of role provides the same degree of assurance in the change of access authorizations for the user and the processes acting on behalf of the user as would be provided by a change between a privileged and non-privileged account."
+                  }
+                ]
+              },
+              {
+                "id": "ac-6.3",
+                "class": "SP800-53-enhancement",
+                "title": "Network Access to Privileged Commands",
+                "params": [
+                  {
+                    "id": "ac-6.3_prm_1",
+                    "label": "organization-defined privileged commands"
+                  },
+                  {
+                    "id": "ac-6.3_prm_2",
+                    "label": "organization-defined compelling operational needs"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(3)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.03"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ac-17",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ac-18",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ac-19",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.3_smt",
+                    "name": "statement",
+                    "prose": "Authorize network access to {{ insert: param, ac-6.3_prm_1 }} only for {{ insert: param, ac-6.3_prm_2 }} and document the rationale for such access in the security plan for the system."
+                  },
+                  {
+                    "id": "ac-6.3_gdn",
+                    "name": "guidance",
+                    "prose": "Network access is any access across a network connection in lieu of local access (i.e., user being physically present at the device)."
+                  }
+                ]
+              },
+              {
+                "id": "ac-6.4",
+                "class": "SP800-53-enhancement",
+                "title": "Separate Processing Domains",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(4)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.04"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ac-4",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#sc-2",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#sc-3",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#sc-30",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#sc-32",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#sc-39",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.4_smt",
+                    "name": "statement",
+                    "prose": "Provide separate processing domains to enable finer-grained allocation of user privileges."
+                  },
+                  {
+                    "id": "ac-6.4_gdn",
+                    "name": "guidance",
+                    "prose": "Providing separate processing domains for finer-grained allocation of user privileges includes using virtualization techniques to permit additional user privileges within a virtual machine while restricting privileges to other virtual machines or to the underlying physical machine, implementing separate physical domains, and employing hardware or software domain separation mechanisms."
+                  }
+                ]
+              },
+              {
+                "id": "ac-6.5",
+                "class": "SP800-53-enhancement",
+                "title": "Privileged Accounts",
+                "params": [
+                  {
+                    "id": "ac-6.5_prm_1",
+                    "label": "organization-defined personnel or roles"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(5)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.05"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ia-2",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ma-3",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ma-4",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.5_smt",
+                    "name": "statement",
+                    "prose": "Restrict privileged accounts on the system to {{ insert: param, ac-6.5_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-6.5_gdn",
+                    "name": "guidance",
+                    "prose": "Privileged accounts, including super user accounts, are typically described as system administrator for various types of commercial off-the-shelf operating systems. Restricting privileged accounts to specific personnel or roles prevents day-to-day users from accessing privileged information or privileged functions. Organizations may differentiate in the application of restricting privileged accounts between allowed privileges for local accounts and for domain accounts provided that they retain the ability to control system configurations for key parameters and as otherwise necessary to sufficiently mitigate risk."
+                  }
+                ]
+              },
+              {
+                "id": "ac-6.6",
+                "class": "SP800-53-enhancement",
+                "title": "Privileged Access by Non-organizational Users",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(6)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.06"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ac-18",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ac-19",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ia-2",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#ia-8",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.6_smt",
+                    "name": "statement",
+                    "prose": "Prohibit privileged access to the system by non-organizational users."
+                  },
+                  {
+                    "id": "ac-6.6_gdn",
+                    "name": "guidance",
+                    "prose": "An organizational user is an employee or an individual considered by the organization to have the equivalent status of an employee. Organizational users include contractors, guest researchers, or individuals detailed from other organizations. A non-organizational user is a user who is not an organizational user. Policies and procedures for granting equivalent status of employees to individuals include a need-to-know, citizenship, and the relationship to the organization."
+                  }
+                ]
+              },
+              {
+                "id": "ac-6.7",
+                "class": "SP800-53-enhancement",
+                "title": "Review of User Privileges",
+                "params": [
+                  {
+                    "id": "ac-6.7_prm_1",
+                    "label": "organization-defined frequency"
+                  },
+                  {
+                    "id": "ac-6.7_prm_2",
+                    "label": "organization-defined roles or classes of users"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(7)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.07"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ca-7",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.7_smt",
+                    "name": "statement",
+                    "parts": [
+                      {
+                        "id": "ac-6.7_smt.a",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(a)"
+                          }
+                        ],
+                        "prose": "Review {{ insert: param, ac-6.7_prm_1 }} the privileges assigned to {{ insert: param, ac-6.7_prm_2 }} to validate the need for such privileges; and"
+                      },
+                      {
+                        "id": "ac-6.7_smt.b",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "(b)"
+                          }
+                        ],
+                        "prose": "Reassign or remove privileges, if necessary, to correctly reflect organizational mission and business needs."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "ac-6.7_gdn",
+                    "name": "guidance",
+                    "prose": "The need for certain assigned user privileges may change over time to reflect changes in organizational mission and business functions, environments of operation, technologies, or threats. A periodic review of assigned user privileges is necessary to determine if the rationale for assigning such privileges remains valid. If the need cannot be revalidated, organizations take appropriate corrective actions."
+                  }
+                ]
+              },
+              {
+                "id": "ac-6.8",
+                "class": "SP800-53-enhancement",
+                "title": "Privilege Levels for Code Execution",
+                "params": [
+                  {
+                    "id": "ac-6.8_prm_1",
+                    "label": "organization-defined software"
+                  }
+                ],
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(8)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.08"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.8_smt",
+                    "name": "statement",
+                    "prose": "Prevent the following software from executing at higher privilege levels than users executing the software: {{ insert: param, ac-6.8_prm_1 }}."
+                  },
+                  {
+                    "id": "ac-6.8_gdn",
+                    "name": "guidance",
+                    "prose": "In certain situations, software applications or programs need to execute with elevated privileges to perform required functions. However, depending on the software functionality and configuration, if the privileges required for execution are at a higher level than the privileges assigned to organizational users invoking such applications or programs, those users may indirectly be provided with greater privileges than assigned."
+                  }
+                ]
+              },
+              {
+                "id": "ac-6.9",
+                "class": "SP800-53-enhancement",
+                "title": "Log Use of Privileged Functions",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(9)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.09"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#au-2",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-3",
+                    "rel": "related"
+                  },
+                  {
+                    "href": "#au-12",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.9_smt",
+                    "name": "statement",
+                    "prose": "Log the execution of privileged functions."
+                  },
+                  {
+                    "id": "ac-6.9_gdn",
+                    "name": "guidance",
+                    "prose": "The misuse of privileged functions, either intentionally or unintentionally by authorized users or by unauthorized external entities that have compromised system accounts, is a serious and ongoing concern and can have significant adverse impacts on organizations. Logging and analyzing the use of privileged functions is one way to detect such misuse and, in doing so, help mitigate the risk from insider threats and the advanced persistent threat."
+                  }
+                ]
+              },
+              {
+                "id": "ac-6.10",
+                "class": "SP800-53-enhancement",
+                "title": "Prohibit Non-privileged Users from Executing Privileged Functions",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AC-6(10)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "ac-06.10"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#ac-6",
+                    "rel": "required"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ac-6.10_smt",
+                    "name": "statement",
+                    "prose": "Prevent non-privileged users from executing privileged functions."
+                  },
+                  {
+                    "id": "ac-6.10_gdn",
+                    "name": "guidance",
+                    "prose": "Privileged functions include disabling, circumventing, or altering implemented security or privacy controls, establishing system accounts, performing system integrity checks, and administering cryptographic key management activities. Non-privileged users are individuals who do not possess appropriate authorizations. Privileged functions that require protection from non-privileged users include circumventing intrusion detection and prevention mechanisms or malicious code protection mechanisms. Preventing non-privileged users from executing privileged functions is enforced by [AC-3](#ac-3)."
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "at",
+        "class": "family",
+        "title": "Awareness and Training",
+        "controls": [
+          {
+            "id": "at-1",
+            "class": "SP800-53",
+            "title": "Policy and Procedures",
+            "params": [
+              {
+                "id": "at-1_prm_1",
+                "label": "organization-defined personnel or roles"
+              },
+              {
+                "id": "at-1_prm_2",
+                "select": {
+                  "how-many": "one-or-more",
+                  "choice": [
+                    "Organization-level",
+                    "Mission/business process-level"
+                  ]
+                }
+              }
+            ],
+            "props": [
+              {
+                "name": "label",
+                "value": "AT-1"
+              },
+              {
+                "name": "sort-id",
+                "value": "at-01"
+              }
+            ],
+            "links": [
+              {
+                "href": "#27847491-5ce1-4f6a-a1e4-9e483782f0ef",
+                "rel": "reference"
+              },
+              {
+                "href": "#c7ac44e8-10db-4b64-b2b9-9e32ec1efed0",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "at-1_smt",
+                "name": "statement",
+                "parts": [
+                  {
+                    "id": "at-1_smt.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "a."
+                      }
+                    ],
+                    "prose": "Develop, document, and disseminate to {{ insert: param, at-1_prm_1 }}:",
+                    "parts": [
+                      {
+                        "id": "at-1_smt.a.1",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "1."
+                          }
+                        ],
+                        "prose": " {{ insert: param, at-1_prm_2 }} awareness and training policy that:",
+                        "parts": [
+                          {
+                            "id": "at-1_smt.a.1.a",
+                            "name": "item",
+                            "props": [
+                              {
+                                "name": "label",
+                                "value": "(a)"
+                              }
+                            ],
+                            "prose": "Addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and"
+                          },
+                          {
+                            "id": "at-1_smt.a.1.b",
+                            "name": "item",
+                            "props": [
+                              {
+                                "name": "label",
+                                "value": "(b)"
+                              }
+                            ],
+                            "prose": "Is consistent with applicable laws, executive orders, directives, regulations, policies, standards, and guidelines; and"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "at-1_smt.a.2",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "2."
+                          }
+                        ],
+                        "prose": "Procedures to facilitate the implementation of the awareness and training policy and the associated awareness and training controls;"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "at-1_smt.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "b."
+                      }
+                    ],
+                    "prose": "Designate an {{ insert: param, at-1_prm_1 }} to manage the development, documentation, and dissemination of the awareness and training policy and procedures; and"
+                  }
+                ]
+              },
+              {
+                "id": "at-1_gdn",
+                "name": "guidance",
+                "prose": "Awareness and training policy and procedures address the controls in the AT family that are implemented within systems and organizations. The risk management strategy is an important factor in establishing such policies and procedures. Policies and procedures contribute to security and privacy assurance. Therefore, it is important that security and privacy programs collaborate on the development of awareness and training policy and procedures. Security and privacy program policies and procedures at the organization level are preferable, in general, and may obviate the need for mission- or system-specific policies and procedures. The policy can be included as part of the general security and privacy policy or be represented by multiple policies that reflect the complex nature of organizations. Procedures can be established for security and privacy programs, for mission or business processes, and for systems, if needed. Procedures describe how the policies or controls are implemented and can be directed at the individual or role that is the object of the procedure. Procedures can be documented in system security and privacy plans or in one or more separate documents. Events that may precipitate an update to awareness and training policy and procedures include assessment or audit findings, security incidents or breaches, or changes in applicable laws, executive orders, directives, regulations, policies, standards, and guidelines. Simply restating controls does not constitute an organizational policy or procedure."
+              }
+            ]
+          },
+          {
+            "id": "at-2",
+            "class": "SP800-53",
+            "title": "Literacy Training and Awareness",
+            "params": [
+              {
+                "id": "at-2_prm_1",
+                "label": "organization-defined frequency"
+              },
+              {
+                "id": "at-2_prm_2",
+                "label": "organization-defined events"
+              }
+            ],
+            "props": [
+              {
+                "name": "label",
+                "value": "AT-2"
+              },
+              {
+                "name": "sort-id",
+                "value": "at-02"
+              }
+            ],
+            "links": [
+              {
+                "href": "#27847491-5ce1-4f6a-a1e4-9e483782f0ef",
+                "rel": "reference"
+              },
+              {
+                "href": "#511f6832-23ca-49a3-8c0f-ce493373cab8",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "at-2_smt",
+                "name": "statement",
+                "parts": [
+                  {
+                    "id": "at-2_smt.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "a."
+                      }
+                    ],
+                    "prose": "Provide security and privacy literacy training to system users (including managers, senior executives, and contractors):",
+                    "parts": [
+                      {
+                        "id": "at-2_smt.a.1",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "1."
+                          }
+                        ],
+                        "prose": "As part of initial training for new users and {{ insert: param, at-2_prm_1 }} thereafter; and"
+                      },
+                      {
+                        "id": "at-2_smt.a.2",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "2."
+                          }
+                        ],
+                        "prose": "When required by system changes or following {{ insert: param, at-2_prm_2 }};"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "at-2_smt.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "b."
+                      }
+                    ],
+                    "prose": "Employ the following techniques to increase the security and privacy awareness of system users {{ insert: param, at-2_prm_1 }};"
+                  }
+                ]
+              },
+              {
+                "id": "at-2_gdn",
+                "name": "guidance",
+                "prose": "Organizations provide basic and advanced levels of literacy training to system users, including measures to test the knowledge level of users. Organizations determine the content of literacy training and awareness based on specific organizational requirements, the systems to which personnel have authorized access, and work environments (e.g., telework). The content includes an understanding of the need for security and privacy as well as actions by users to maintain security and personal privacy and to respond to suspected incidents. The content addresses the need for operations security and the handling of personally identifiable information.\n\nAwareness techniques include displaying posters, offering supplies inscribed with security and privacy reminders, displaying logon screen messages, generating email advisories or notices from organizational officials, and conducting awareness events. Literacy training after the initial training described in [AT-2a.1](#at-2_smt.a.1) is conducted at a minimum frequency consistent with applicable laws, directives, regulations, and policies. Subsequent literacy training may be satisfied by one or more short ad hoc sessions and include topical information on recent attack schemes, changes to organizational security and privacy policies, revised security and privacy expectations, or a subset of topics from the initial training. Updating literacy training and awareness content on a regular basis helps to ensure that the content remains relevant. Events that may precipitate an update to literacy training and awareness content include, but are not limited to, assessment or audit findings, security incidents or breaches, or changes in applicable laws, executive orders, directives, regulations, policies, standards, and guidelines."
+              }
+            ],
+            "controls": [
+              {
+                "id": "at-2.1",
+                "class": "SP800-53-enhancement",
+                "title": "Practical Exercises",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AT-2(1)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "at-02.01"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#at-2",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#ca-2",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "at-2.1_smt",
+                    "name": "statement",
+                    "prose": "Provide practical exercises in literacy training that simulate events and incidents."
+                  },
+                  {
+                    "id": "at-2.1_gdn",
+                    "name": "guidance",
+                    "prose": "Practical exercises include no-notice social engineering attempts to collect information, gain unauthorized access, or simulate the adverse impact of opening malicious email attachments or invoking, via spear phishing attacks, malicious web links."
+                  }
+                ]
+              },
+              {
+                "id": "at-2.2",
+                "class": "SP800-53-enhancement",
+                "title": "Insider Threat",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "AT-2(2)"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "at-02.02"
+                  }
+                ],
+                "links": [
+                  {
+                    "href": "#at-2",
+                    "rel": "required"
+                  },
+                  {
+                    "href": "#pm-12",
+                    "rel": "related"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "at-2.2_smt",
+                    "name": "statement",
+                    "prose": "Provide literacy training on recognizing and reporting potential indicators of insider threat."
+                  },
+                  {
+                    "id": "at-2.2_gdn",
+                    "name": "guidance",
+                    "prose": "Potential indicators and possible precursors of insider threat can include behaviors such as inordinate, long-term job dissatisfaction; attempts to gain access to information not required for job performance; unexplained access to financial resources; bullying or harassment of fellow employees; workplace violence; and other serious violations of policies, procedures, directives, regulations, rules, or practices. Literacy training includes how to communicate the concerns of employees and management regarding potential indicators of insider threat through channels established by the organization and in accordance with established policies and procedures. Organizations may consider tailoring insider threat awareness topics to the role. For example, training for managers may be focused on changes in the behavior of team members, while training for employees may be focused on more general observations."
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "back-matter": {
+      "resources": [
+        {
+          "uuid": "91f992fb-f668-4c91-a50f-0f05b95ccee3",
+          "title": "32 CFR 2002",
+          "citation": {
+            "text": "Code of Federal Regulations, Title 32, *Controlled Unclassified Information* (32 C.F.R. 2002)."
+          },
+          "rlinks": [
+            {
+              "href": "https://www.federalregister.gov/documents/2016/09/14/2016-21665/controlled-unclassified-information"
+            }
+          ]
+        },
+        {
+          "uuid": "0f963c17-ab5a-432a-a867-91eac550309b",
+          "title": "41 CFR 201",
+          "citation": {
+            "text": " \"Federal Acquisition Supply Chain Security Act; Rule,\" 85 Federal Register 54263 (September 1, 2020), pp 54263-54271."
+          },
+          "rlinks": [
+            {
+              "href": "https://www.federalregister.gov/d/2020-18939"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/unit/utils/oscal/data/simplified_nist_profile.json
+++ b/tests/unit/utils/oscal/data/simplified_nist_profile.json
@@ -1,0 +1,142 @@
+{
+  "profile": {
+    "uuid": "1019f424-1556-4aa3-9df3-337b97c2c856",
+    "metadata": {
+      "title": "NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE",
+      "last-modified": "2021-06-08T13:57:34.337491-04:00",
+      "version": "Final",
+      "oscal-version": "1.0.0",
+      "roles": [
+        {
+          "id": "creator",
+          "title": "Document Creator"
+        },
+        {
+          "id": "contact",
+          "title": "Contact"
+        }
+      ],
+      "parties": [
+        {
+          "uuid": "cde369ce-57f8-4ec1-847f-2681a9a881e7",
+          "type": "organization",
+          "name": "Joint Task Force, Transformation Initiative",
+          "email-addresses": [
+            "sec-cert@nist.gov"
+          ],
+          "addresses": [
+            {
+              "addr-lines": [
+                "National Institute of Standards and Technology",
+                "Attn: Computer Security Division",
+                "Information Technology Laboratory",
+                "100 Bureau Drive (Mail Stop 8930)"
+              ],
+              "city": "Gaithersburg",
+              "state": "MD",
+              "postal-code": "20899-8930"
+            }
+          ]
+        }
+      ],
+      "responsible-parties": [
+        {
+          "role-id": "creator",
+          "party-uuids": [
+            "cde369ce-57f8-4ec1-847f-2681a9a881e7"
+          ]
+        },
+        {
+          "role-id": "contact",
+          "party-uuids": [
+            "cde369ce-57f8-4ec1-847f-2681a9a881e7"
+          ]
+        }
+      ]
+    },
+    "imports": [
+      {
+        "href": "trestle://catalogs/simplified_nist_catalog/catalog.json",
+        "include-controls": [
+          {
+            "with-ids": [
+              "ac-1",
+              "ac-2",
+              "ac-2.1",
+              "ac-2.2",
+              "ac-2.3",
+              "ac-2.4",
+              "ac-2.5",
+              "ac-2.13",
+              "ac-3",
+              "ac-4",
+              "ac-4.4",
+              "ac-5"
+            ]
+          }
+        ]
+      }
+    ],
+    "merge": {
+      "as-is": true
+    },
+    "modify": {
+      "set-parameters": [
+        {
+          "param_id": "ac-1_prm_1",
+          "class": "newclassfromprof",
+          "depends-on": "newdependsonfromprof",
+          "usage": "new usage from prof",
+          "props": [
+            {
+              "name": "param_1_prop",
+              "value": "prop value from prof"
+            },
+            {
+              "name": "param_1_prop_2",
+              "value": "new prop value from prof"
+            }
+          ],
+          "links": [
+            {
+              "href": "#123456789",
+              "text": "new text from prof"
+            },
+            {
+              "href": "#new_link",
+              "text": "new link text"
+            }
+          ],
+          "constraints": [
+            {
+              "description": "new constraint"
+            }
+          ],
+          "guidelines": [
+            {
+              "prose": "new guideline"
+            }
+          ]
+        },
+        {
+          "param_id": "ac-4.4_prm_3",
+          "values": [
+            "hacking the system"
+          ]
+        },
+        {
+          "param_id": "loose_2",
+          "values": [
+            "loose_2_val_from_prof"
+          ]
+        },
+        {
+          "param_id": "bad_param_id",
+          "values": [
+            "this will cause warning"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/unit/utils/oscal/data/test_root/controls/test_policy.yml
+++ b/tests/unit/utils/oscal/data/test_root/controls/test_policy.yml
@@ -1,0 +1,74 @@
+policy: Simplied NIST Policy
+title: Simplified NIST Reccomendations for OCP4
+id: test_policy
+version: Revision 4
+source: https://www.fedramp.gov/assets/resources/documents/FedRAMP_Security_Controls_Baseline.xlsx
+levels:
+- id: low
+- id: moderate
+- id: high
+controls:
+- id: AC-1
+  status: not applicable
+  notes: |-
+    Section a: AC-1(a) is an organizational control outside the scope of OpenShift configuration.
+
+    Section b: AC-1(b) is an organizational control outside the scope of OpenShift configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. An access control policy that\
+    \ addresses purpose, scope, roles, responsibilities, management commitment, coordination\
+    \ among organizational entities, and compliance; and\n   2. Procedures to facilitate\
+    \ the implementation of the access control policy and associated access controls;\
+    \ and\n b. Reviews and updates the current:\n   1. Access control policy [Assignment:\
+    \ organization-defined frequency]; and\n   2. Access control procedures [Assignment:\
+    \ organization-defined frequency].\n\nSupplemental Guidance: This control addresses\
+    \ the establishment of policy and procedures for the effective implementation\
+    \ of selected security controls and control enhancements in the AC family. Policy\
+    \ and procedures reflect applicable federal laws, Executive Orders, directives,\
+    \ regulations, policies, standards, and guidance. Security program policies and\
+    \ procedures at the organization level may make the need for system-specific policies\
+    \ and procedures unnecessary. The policy can be included as part of the general\
+    \ information security policy for organizations or conversely, can be represented\
+    \ by multiple policies reflecting the complex nature of certain organizations.\
+    \ The procedures can be established for the security program in general and for\
+    \ particular information systems, if needed. \n\nThe organizational risk management\
+    \ strategy is a key factor in establishing policy and procedures. Related control:\
+    \ PM-9.\nControl Enhancements: None.\nReferences: NIST Special Publications 800-12,\
+    \ 800-100.\n\nAC-1 (b) (1) [at least annually] \nAC-1 (b) (2) [at least annually\
+    \ or whenever a significant change occurs]"
+  title: >-
+    AC-1 - ACCESS CONTROL POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-6(3)
+  status: automated
+  notes: |-
+    Organizational analysis and correlation of audit records across
+    different repositories to gain organization-wide
+    situational awareness is outside the scope
+    of OpenShift configuration.
+
+    To aide in such organizational processes, note that OpenShift's
+    Cluster Logging Operator enables OpenShift administrators to
+    configure custom pipelines to send OpenShift cluster logs to remote
+    log stores. These remote destinations, such as Elastic or
+    Splunk endpoints, could be used for information system-wide correlation.
+
+    Documentation regarding how to forward cluster logs using the
+    Cluster Logging Operator to specific endpoints can be found at:
+
+    https://docs.openshift.com/container-platform/latest/logging/cluster-logging.html
+  rules:
+  - audit_log_forwarding_enabled
+  description: |-
+    The organization analyzes and correlates audit records across different repositories to gain organization-wide situational awareness.
+
+    Supplemental Guidance:  Organization-wide situational awareness includes awareness across all three tiers of risk management (i.e., organizational, mission/business process, and information system) and supports cross-organization awareness. Related controls: AU-12, IR-4.
+  title: >-
+    AU-6(3) - AUDIT REVIEW, ANALYSIS, AND REPORTING | CORRELATE AUDIT REPOSITORIES
+  levels:
+  - high
+  - moderate

--- a/tests/unit/utils/oscal/data/test_root/products/test_product/product.yml
+++ b/tests/unit/utils/oscal/data/test_root/products/test_product/product.yml
@@ -1,0 +1,131 @@
+product: ocp4
+full_name: Red Hat OpenShift Container Platform 4
+type: platform
+
+benchmark_id: OCP-4
+benchmark_root: "../../applications"
+
+profiles_root: "./profiles"
+
+pkg_system: "rpm"
+
+init_system: "systemd"
+
+reference_uris:
+  cis: 'https://www.cisecurity.org/benchmark/kubernetes/'
+
+cpes_root: "../../shared/applicability"
+cpes:
+  - ocp4:
+      name: "cpe:/a:redhat:openshift_container_platform:4.1"
+      title: "Red Hat OpenShift Container Platform 4"
+      check_id: installed_app_is_ocp4
+
+  - ocp4-node:
+      name: "cpe:/o:redhat:openshift_container_platform_node:4"
+      title: "Red Hat OpenShift Container Platform 4 Node"
+      check_id: installed_app_is_ocp4_node
+
+  - ocp4-node-on-ovn:
+      name: "cpe:/a:redhat:openshift_container_platform_node_on_ovn:4"
+      title: "Red Hat OpenShift Container Platform 4 Node on OVN"
+      check_id: installed_app_is_ocp4_node_on_openshift-ovn
+
+  - ocp4-node-on-sdn:
+      name: "cpe:/a:redhat:openshift_container_platform_node_on_sdn:4"
+      title: "Red Hat OpenShift Container Platform 4 Node on SDN"
+      check_id: installed_app_is_ocp4_node_on_openshift-sdn
+
+  - ocp4.6:
+      name: "cpe:/a:redhat:openshift_container_platform:4.6"
+      title: "Red Hat OpenShift Container Platform 4.6"
+      check_id: installed_app_is_ocp4_6
+
+  - ocp4.7:
+      name: "cpe:/a:redhat:openshift_container_platform:4.7"
+      title: "Red Hat OpenShift Container Platform 4.7"
+      check_id: installed_app_is_ocp4_7
+
+  - ocp4.8:
+      name: "cpe:/a:redhat:openshift_container_platform:4.8"
+      title: "Red Hat OpenShift Container Platform 4.8"
+      check_id: installed_app_is_ocp4_8
+
+  - ocp4.9:
+      name: "cpe:/a:redhat:openshift_container_platform:4.9"
+      title: "Red Hat OpenShift Container Platform 4.9"
+      check_id: installed_app_is_ocp4_9
+
+  - ocp4.10:
+      name: "cpe:/a:redhat:openshift_container_platform:4.10"
+      title: "Red Hat OpenShift Container Platform 4.10"
+      check_id: installed_app_is_ocp4_10
+
+  - ocp4.11:
+      name: "cpe:/a:redhat:openshift_container_platform:4.11"
+      title: "Red Hat OpenShift Container Platform 4.11"
+      check_id: installed_app_is_ocp4_11
+
+  - ocp4.12:
+      name: "cpe:/a:redhat:openshift_container_platform:4.12"
+      title: "Red Hat OpenShift Container Platform 4.12"
+      check_id: installed_app_is_ocp4_12
+
+  - ocp4.13:
+      name: "cpe:/a:redhat:openshift_container_platform:4.13"
+      title: "Red Hat OpenShift Container Platform 4.13"
+      check_id: installed_app_is_ocp4_13
+
+  - ocp4.14:
+      name: "cpe:/a:redhat:openshift_container_platform:4.14"
+      title: "Red Hat OpenShift Container Platform 4.14"
+      check_id: installed_app_is_ocp4_14
+
+  - ocp4.15:
+      name: "cpe:/a:redhat:openshift_container_platform:4.15"
+      title: "Red Hat OpenShift Container Platform 4.15"
+      check_id: installed_app_is_ocp4_15
+
+  - ocp4.16:
+      name: "cpe:/a:redhat:openshift_container_platform:4.16"
+      title: "Red Hat OpenShift Container Platform 4.16"
+      check_id: installed_app_is_ocp4_16
+
+  - ocp4.17:
+      name: "cpe:/a:redhat:openshift_container_platform:4.17"
+      title: "Red Hat OpenShift Container Platform 4.17"
+      check_id: installed_app_is_ocp4_17
+
+  - ocp4.18:
+      name: "cpe:/a:redhat:openshift_container_platform:4.18"
+      title: "Red Hat OpenShift Container Platform 4.18"
+      check_id: installed_app_is_ocp4_18
+
+  - ocp4-on-aws:
+      name: "cpe:/a:redhat:openshift_container_platform_on_aws:4"
+      title: "Red Hat OpenShift Container Platform 4 on AWS"
+      check_id: installed_app_is_ocp4_on_aws
+
+  - ocp4-on-azure:
+      name: "cpe:/a:redhat:openshift_container_platform_on_azure:4"
+      title: "Red Hat OpenShift Container Platform 4 on Azure"
+      check_id: installed_app_is_ocp4_on_azure
+
+  - ocp4-on-gcp:
+      name: "cpe:/a:redhat:openshift_container_platform_on_gcp:4"
+      title: "Red Hat OpenShift Container Platform 4 on GCP"
+      check_id: installed_app_is_ocp4_on_gcp
+
+  - ocp4-on-ovn:
+      name: "cpe:/a:redhat:openshift_container_platform_on_ovn:4"
+      title: "Red Hat OpenShift Container Platform 4 on OVN"
+      check_id: installed_app_is_ocp4_on_openshiftovn
+
+  - ocp4-on-sdn:
+      name: "cpe:/a:redhat:openshift_container_platform_on_sdn:4"
+      title: "Red Hat OpenShift Container Platform 4 on SDN"
+      check_id: installed_app_is_ocp4_on_openshiftsdn
+
+
+# Requirement string, see: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirements-parsing
+# requires: "openscap>=1.3.4"

--- a/tests/unit/utils/oscal/test_cd_generator.py
+++ b/tests/unit/utils/oscal/test_cd_generator.py
@@ -1,0 +1,123 @@
+import argparse
+import os
+import pytest
+import pathlib
+import shutil
+
+from tempfile import TemporaryDirectory
+
+from trestle.common.err import TrestleError
+from trestle.core.generators import generate_sample_model
+from trestle.common.model_utils import ModelUtils
+from trestle.core.commands.init import InitCmd
+from trestle.core.models.file_content_type import FileContentType
+from trestle.oscal import catalog as cat
+from trestle.oscal import profile as prof
+from trestle.oscal.component import ImplementedRequirement
+
+from utils.oscal.cd_generator import ComponentDefinitionGenerator
+
+DATADIR = os.path.join(os.path.dirname(__file__), "data")
+TEST_ROOT = os.path.abspath(os.path.join(DATADIR, "test_root"))
+TEST_BUILD_CONFIG = os.path.join(DATADIR, "build-config.yml")
+TEST_RULE_JSON = os.path.join(DATADIR, "rule_dirs.json")
+
+
+@pytest.fixture(scope="function")
+def vendor_dir():
+    """Create a temporary trestle directory for testing."""
+    with TemporaryDirectory(prefix="temp_vendor") as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        try:
+            args = argparse.Namespace(
+                verbose=0,
+                trestle_root=tmp_path,
+                full=True,
+                local=False,
+                govdocs=False,
+            )
+            init = InitCmd()
+            init._run(args)
+            load_oscal_test_data(tmp_path, 'simplified_nist_catalog', cat.Catalog)
+            load_oscal_test_data(tmp_path, 'simplified_nist_profile', prof.Profile)
+        except Exception as e:
+            raise TrestleError(
+                f'Initialization failed for temporary trestle directory: {e}.'
+            )
+        yield tmpdir
+
+
+def load_oscal_test_data(trestle_dir, model_name, model_type):
+    dst_path = ModelUtils.get_model_path_for_name_and_class(
+        trestle_dir, model_name, model_type, FileContentType.JSON  # type: ignore
+    )
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    src_path = os.path.join(DATADIR, model_name + '.json')
+    shutil.copy2(src_path, dst_path)
+
+
+@pytest.mark.parametrize(
+    "input, response",
+    [
+        ('AC-1', 'ac-1'),
+        ('AC-2(2)', 'ac-2.2'),
+        ('ac-1_smt.a', 'ac-1_smt.a'),
+        ('AC-200', None),
+    ]
+)
+def test_get_control_profile_id(vendor_dir, input, response):
+    "Test get_control_profile_id"
+    cd_generator = ComponentDefinitionGenerator(
+        product='test_product',
+        vendor_dir=vendor_dir,
+        build_config_yaml=TEST_BUILD_CONFIG,
+        json_path=TEST_RULE_JSON,
+        root=TEST_ROOT,
+        profile_name_or_href='simplified_nist_profile',
+        control="test_policy"
+    )
+    result_id = cd_generator.get_profile_control_id(input)
+    assert result_id == response
+
+
+section_response = """
+Section a: My response is a single statement
+Section b: My response is a list of statements
+
+This link for section b.
+"""
+
+single_response = """
+A single response with no sections
+"""
+
+
+def test_handle_response(vendor_dir):
+    """Test handling responses"""
+    cd_generator = ComponentDefinitionGenerator(
+        product='test_product',
+        vendor_dir=vendor_dir,
+        build_config_yaml=TEST_BUILD_CONFIG,
+        json_path=TEST_RULE_JSON,
+        root=TEST_ROOT,
+        profile_name_or_href='simplified_nist_profile',
+        control="test_policy"
+    )
+
+    # test with sections
+    implemented_req = generate_sample_model(ImplementedRequirement)
+    implemented_req.control_id = 'ac-1'
+    cd_generator.handle_response(implemented_req, section_response)
+
+    assert len(implemented_req.statements) == 2
+    assert implemented_req.statements[0].description == 'My response is a single statement'
+    expected_text = "My response is a list of statements\n\nThis link for section b."
+    assert implemented_req.statements[1].description == expected_text
+
+    # test single
+    implemented_req = generate_sample_model(ImplementedRequirement)
+    implemented_req.control_id = 'ac-1'
+    cd_generator.handle_response(implemented_req, single_response)
+
+    assert implemented_req.statements is None
+    assert implemented_req.description == 'A single response with no sections'

--- a/utils/oscal/__init__.py
+++ b/utils/oscal/__init__.py
@@ -1,0 +1,8 @@
+#! /usr/bin/python3
+
+import os
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+VENDOR_ROOT = os.path.join(SSG_ROOT, "vendor")
+RULES_JSON = os.path.join(SSG_ROOT, "build", "rule_dirs.json")
+BUILD_CONFIG = os.path.join(SSG_ROOT, "build", "build_config.yml")

--- a/utils/oscal/build_cd_for_product.py
+++ b/utils/oscal/build_cd_for_product.py
@@ -1,41 +1,18 @@
 #! /usr/bin/python3
 
-"""Build a component definition for a product from pre-existing profiles"""
+"""CLI for building a component definition for a product."""
 
 import argparse
-import json
 import logging
 import os
-import pathlib
 import sys
-import uuid
 
-from trestle.common.const import TRESTLE_HREF_HEADING
-from trestle.core.generators import generate_sample_model
-from trestle.core.catalog.catalog_interface import CatalogInterface
-from trestle.core.control_interface import ControlInterface
-from trestle.core.profile_resolver import ProfileResolver
-from trestle.oscal.component import (
-    ComponentDefinition,
-    DefinedComponent,
-    ControlImplementation,
-    ImplementedRequirement,
-)
-
-import ssg.components
-import ssg.environment
-import ssg.rules
-import ssg.build_yaml
-from ssg.controls import ControlsManager
+from utils.oscal import SSG_ROOT, VENDOR_ROOT, RULES_JSON, BUILD_CONFIG
+from utils.oscal.cd_generator import ComponentDefinitionGenerator
 
 
 logger = logging.getLogger(__name__)
 
-
-SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-VENDOR_ROOT = os.path.join(SSG_ROOT, "vendor")
-RULES_JSON = os.path.join(SSG_ROOT, "build", "rule_dirs.json")
-BUILD_CONFIG = os.path.join(SSG_ROOT, "build", "build_config.yml")
 LOG_FILE = os.path.join(SSG_ROOT, "build", "build_cd_for_product.log")
 
 
@@ -118,204 +95,6 @@ def configure_logger(log_file=None, log_level=logging.INFO):
     console_handler.setLevel(log_level)
     console_handler.setFormatter(formatter_console)
     logger.addHandler(console_handler)
-
-
-class ComponentDefinitionGenerator:
-    """Generate a component definition from a product"""
-
-    def __init__(
-        self,
-        product,
-        root,
-        json_path,
-        build_config_yaml,
-        vendor_dir,
-        profile_name_or_href,
-        control,
-    ):
-        """
-        Initialize the component definition generator and load the necessary files.
-
-        Args:
-            product: Product to generate the component definition for
-            root: Root of the SSG project
-            json_path: Path to the rules_dir.json file
-            build_config_yaml: Path to the build_config.yml file
-            vendor_dir: Path to the vendor directory
-            profile_name_or_href: Name or href of the profile to use
-        """
-        self.trestle_root = pathlib.Path(vendor_dir)
-        self.product = product
-        self.root = root
-
-        profile_path, profile_href = self.get_source(profile_name_or_href)
-        self.profile_path = profile_path
-        self.profile_href = profile_href
-
-        # Try to match by profile and then by label
-        (
-            self.profile_controls,
-            self.controls_by_label,
-        ) = self.resolve_profile_to_controls()
-
-        self.env_yaml = self.get_env_yaml(build_config_yaml)
-        self.policy_id = control
-        self.controls_mgr = self.get_controls_mgr(control)
-
-        with open(json_path, 'r') as f:
-            rule_dir_json = json.load(f)
-        self.rule_json = rule_dir_json
-
-    def get_env_yaml(self, build_config_yaml):
-        """Get the environment yaml."""
-        product_dir = os.path.join(self.root, "products", self.product)
-        product_yaml_path = os.path.join(product_dir, "product.yml")
-        env_yaml = ssg.environment.open_environment(
-            build_config_yaml,
-            product_yaml_path,
-            os.path.join(self.root, "product_properties"),
-        )
-        return env_yaml
-
-    def get_source(self, profile_name_or_href):
-        """Get the source of the profile."""
-        profile_in_trestle_dir = '://' not in profile_name_or_href
-        profile_href = profile_name_or_href
-        if profile_in_trestle_dir:
-            local_path = f'profiles/{profile_name_or_href}/profile.json'
-            profile_href = TRESTLE_HREF_HEADING + local_path
-            profile_path = self.trestle_root / local_path
-        else:
-            profile_path = profile_href
-
-        return profile_path, profile_href
-
-    def get_controls_mgr(self, control):
-        """Get the control response and implementation status from the policy."""
-        controls_dir = os.path.join(self.root, "controls")
-        controls_manager = ControlsManager(
-            controls_dir=controls_dir, env_yaml=self.env_yaml
-        )
-        controls_manager.load()
-        if control not in controls_manager.policies:
-            raise ValueError(f"Policy {control} not found in controls")
-        return controls_manager
-
-    def resolve_profile_to_controls(self):
-        """
-        Resolve the profile to a list of control ids.
-
-        Returns:
-            profile_controls: List of control ids in the profile
-            controls_by_label: Dictionary of controls by label
-        """
-        profile_resolver = ProfileResolver()
-        resolved_catalog = profile_resolver.get_resolved_profile_catalog(
-            self.trestle_root,
-            self.profile_path,
-            block_params=False,
-            params_format='[.]',
-            show_value_warnings=True,
-        )
-        profile_controls = set()
-        controls_by_label = dict()
-
-        for control in CatalogInterface(resolved_catalog).get_all_controls_from_dict():
-            profile_controls.add(control.id)
-            label = ControlInterface.get_label(control)
-            if label:
-                controls_by_label[label] = control.id
-                self.handle_parts(control, profile_controls, controls_by_label)
-        return profile_controls, controls_by_label
-
-    def handle_parts(self, control, profile_controls, controls_by_label):
-        """Handle parts of a control."""
-        if control.parts:
-            for part in control.parts:
-                profile_controls.add(part.id)
-                label = ControlInterface.get_label(part)
-                if label:
-                    controls_by_label[label] = part.id
-                self.handle_parts(part, profile_controls, controls_by_label)
-
-    def handle_rule_yaml(self, rule_id: str):
-        """Create rule object from rule yaml."""
-        rule_dir = self.rule_json[rule_id]['dir']
-        guide_dir = self.rule_json[rule_id]['guide']
-        product = self.env_yaml['product']
-        rule_obj = {'id': rule_id, 'dir': rule_dir, 'guide': guide_dir}
-        rule_file = ssg.rules.get_rule_dir_yaml(rule_dir)
-
-        rule_yaml = ssg.build_yaml.Rule.from_yaml(rule_file, env_yaml=self.env_yaml)
-        rule_yaml.normalize(product)
-        rule_obj['description'] = rule_yaml.description
-        rule_obj['fixtext'] = rule_yaml.fixtext
-        return rule_obj
-
-    def get_profile_control_id(self, control_name):
-        """
-        Get control info if it is in the parent profile if it exists.
-
-        Returns:
-            control_id: The control id if it is in the profile
-        """
-        if control_name in self.controls_by_label.keys():
-            return self.controls_by_label.get(control_name)
-        elif control_name in self.profile_controls:
-            return control_name
-
-        logger.warning(f"Control {control_name} not in profile id or label")
-        return None
-
-    def create_implemented_requirement(self, control):
-        """Create implemented requirement from a control object"""
-
-        logger.info(f"Creating implemented requirement for {control.id}")
-        control_id = self.get_profile_control_id(control.id)
-        if control_id:
-            implemented_req = generate_sample_model(ImplementedRequirement)
-            implemented_req.control_id = control_id
-            implemented_req.description = control.notes
-            # TODO(jpower432): Setup rules in the properties file
-            # TODO(jpower432): Set the implementation status property
-            return implemented_req
-        return None
-
-    def get_control_implementation(self):
-        """Get the control implementation for a component."""
-        ci = generate_sample_model(ControlImplementation)
-        ci.source = self.profile_href
-        all_implement_reqs = list()
-        for control in self.controls_mgr.get_all_controls(self.policy_id):
-            implemented_req = self.create_implemented_requirement(control)
-            if implemented_req:
-                all_implement_reqs.append(implemented_req)
-        ci.implemented_requirements = all_implement_reqs
-        return ci
-
-    def create_cd(self, output, component_definition_type="service"):
-        """Create a component definition and write it to a file."""
-        logger.info(f"Creating component definition for {self.product}")
-        component_definition = generate_sample_model(ComponentDefinition)
-        component_definition.metadata.title = f"Component definition for {self.product}"
-        component_definition.components = list()
-
-        control_implementation = self.get_control_implementation()
-
-        if control_implementation.implemented_requirements:
-            oscal_component = DefinedComponent(
-                uuid=str(uuid.uuid4()),
-                title=self.product,
-                type=component_definition_type,
-                description=self.product,
-                control_implementations=[control_implementation],
-            )
-            component_definition.components.append(oscal_component)
-
-        output_str = output
-        out_path = pathlib.Path(output_str)
-        logger.info(f"Writing component definition to {out_path}")
-        component_definition.oscal_write(out_path)
 
 
 def main():

--- a/utils/oscal/cd_generator.py
+++ b/utils/oscal/cd_generator.py
@@ -1,0 +1,288 @@
+#! /usr/bin/python3
+
+"""Build a component definition for a product from pre-existing profiles"""
+
+import json
+import logging
+import os
+import pathlib
+import re
+import uuid
+
+from trestle.common.const import TRESTLE_HREF_HEADING
+from trestle.core.generators import generate_sample_model
+from trestle.core.catalog.catalog_interface import CatalogInterface
+from trestle.core.control_interface import ControlInterface
+from trestle.core.profile_resolver import ProfileResolver
+from trestle.oscal.component import (
+    ComponentDefinition,
+    DefinedComponent,
+    ControlImplementation,
+    ImplementedRequirement,
+    Statement,
+)
+
+import ssg.components
+import ssg.environment
+import ssg.rules
+import ssg.build_yaml
+from ssg.controls import ControlsManager
+
+
+logger = logging.getLogger(__name__)
+
+SECTION_PATTERN = r'Section ([a-z]):'
+
+
+class ComponentDefinitionGenerator:
+    """Generate a component definition from a product"""
+
+    def __init__(
+        self,
+        product,
+        root,
+        json_path,
+        build_config_yaml,
+        vendor_dir,
+        profile_name_or_href,
+        control,
+    ):
+        """
+        Initialize the component definition generator and load the necessary files.
+
+        Args:
+            product: Product to generate the component definition for
+            root: Root of the SSG project
+            json_path: Path to the rules_dir.json file
+            build_config_yaml: Path to the build_config.yml file
+            vendor_dir: Path to the vendor directory
+            profile_name_or_href: Name or href of the profile to use
+        """
+        self.ssg_root = root
+        self.trestle_root = pathlib.Path(vendor_dir)
+        self.product = product
+
+        profile_path, profile_href = self.get_source(profile_name_or_href)
+        self.profile_path = profile_path
+        self.profile_href = profile_href
+
+        # Used to match by profile control id and then by label property
+        (
+            self.profile_controls,
+            self.controls_by_label,
+        ) = self.resolve_profile_to_controls()
+
+        self.env_yaml = self.get_env_yaml(build_config_yaml)
+        self.policy_id = control
+        self.controls_mgr = self.get_controls_mgr(control)
+
+        with open(json_path, 'r') as f:
+            rule_dir_json = json.load(f)
+        self.rule_json = rule_dir_json
+
+    def get_env_yaml(self, build_config_yaml):
+        """Get the environment yaml."""
+        product_dir = os.path.join(self.ssg_root, "products", self.product)
+        product_yaml_path = os.path.join(product_dir, "product.yml")
+        env_yaml = ssg.environment.open_environment(
+            build_config_yaml,
+            product_yaml_path,
+            os.path.join(self.ssg_root, "product_properties"),
+        )
+        return env_yaml
+
+    def get_source(self, profile_name_or_href):
+        """Get the source of the profile."""
+        profile_in_trestle_dir = '://' not in profile_name_or_href
+        profile_href = profile_name_or_href
+        if profile_in_trestle_dir:
+            local_path = f'profiles/{profile_name_or_href}/profile.json'
+            profile_href = TRESTLE_HREF_HEADING + local_path
+            profile_path = self.trestle_root / local_path
+        else:
+            profile_path = profile_href
+
+        return profile_path, profile_href
+
+    def get_controls_mgr(self, control):
+        """Get the control response and implementation status from the policy."""
+        controls_dir = os.path.join(self.ssg_root, "controls")
+        controls_manager = ControlsManager(
+            controls_dir=controls_dir, env_yaml=self.env_yaml
+        )
+        controls_manager.load()
+        if control not in controls_manager.policies:
+            raise ValueError(f"Policy {control} not found in controls")
+        return controls_manager
+
+    def resolve_profile_to_controls(self):
+        """
+        Resolve the profile to a list of control ids.
+
+        Returns:
+            profile_controls: List of control ids in the profile
+            controls_by_label: Dictionary of controls by label
+        """
+        profile_resolver = ProfileResolver()
+        resolved_catalog = profile_resolver.get_resolved_profile_catalog(
+            self.trestle_root,
+            self.profile_path,
+            block_params=False,
+            params_format='[.]',
+            show_value_warnings=True,
+        )
+        profile_controls = set()
+        controls_by_label = dict()
+
+        for control in CatalogInterface(resolved_catalog).get_all_controls_from_dict():
+            profile_controls.add(control.id)
+            label = ControlInterface.get_label(control)
+            if label:
+                controls_by_label[label] = control.id
+                self.handle_parts(control, profile_controls, controls_by_label)
+        return profile_controls, controls_by_label
+
+    def handle_parts(self, control, profile_controls, controls_by_label):
+        """Handle parts of a control."""
+        if control.parts:
+            for part in control.parts:
+                profile_controls.add(part.id)
+                label = ControlInterface.get_label(part)
+                if label:
+                    controls_by_label[label] = part.id
+                self.handle_parts(part, profile_controls, controls_by_label)
+
+    def handle_rule_yaml(self, rule_id: str):
+        """Create rule object from rule yaml."""
+        rule_dir = self.rule_json[rule_id]['dir']
+        guide_dir = self.rule_json[rule_id]['guide']
+        product = self.env_yaml['product']
+        rule_obj = {'id': rule_id, 'dir': rule_dir, 'guide': guide_dir}
+        rule_file = ssg.rules.get_rule_dir_yaml(rule_dir)
+
+        rule_yaml = ssg.build_yaml.Rule.from_yaml(rule_file, env_yaml=self.env_yaml)
+        rule_yaml.normalize(product)
+        rule_obj['description'] = rule_yaml.description
+        rule_obj['fixtext'] = rule_yaml.fixtext
+        return rule_obj
+
+    def get_profile_control_id(self, control_name):
+        """
+        Get control info if it is in the parent profile.
+
+        Returns:
+            control_id: The control id if it is in the profile
+        """
+        if control_name in self.controls_by_label.keys():
+            logging.debug(f"Found control {control_name} in control labels")
+            return self.controls_by_label.get(control_name)
+        elif control_name in self.profile_controls:
+            logging.debug(f"Found control {control_name} in profile control ids")
+            return control_name
+
+        logger.debug(f"Control {control_name} does not exist in the profile")
+        return None
+
+    def create_implemented_requirement(self, control):
+        """Create implemented requirement from a control object"""
+
+        logger.info(f"Creating implemented requirement for {control.id}")
+        control_id = self.get_profile_control_id(control.id)
+        if control_id:
+            implemented_req = generate_sample_model(ImplementedRequirement)
+            implemented_req.control_id = control_id
+            self.handle_response(implemented_req, control.notes)
+            # TODO(jpower432): Setup rules in the properties file
+            # TODO(jpower432): Set the implementation status property
+            return implemented_req
+        return None
+
+    def handle_response(self, implemented_req, control_response):
+        """
+        Break down the response into parts.
+
+        Args:
+            implemented_req: The implemented requirement to add the response and statements to.
+            control_response: The control response to add to the implemented requirement.
+        """
+        pattern = re.compile(SECTION_PATTERN, re.IGNORECASE)
+        lines = control_response.split('\n')
+
+        sections_dict = dict()
+        current_section_label = None
+
+        for line in lines:
+            match = pattern.match(line)
+
+            if match:
+                current_section_label = match.group(1)
+                sections_dict[current_section_label] = [line]
+            elif current_section_label is not None:
+                sections_dict[current_section_label].append(line)
+
+        if not sections_dict:
+            implemented_req.description = control_response.strip()
+        else:
+            # process into statements
+            implemented_req.statements = list()
+            for section_label, section_content in sections_dict.items():
+                statement_id = self.get_profile_control_id(
+                    f"{implemented_req.control_id}_smt.{section_label}"
+                )
+                if statement_id is None:
+                    continue
+
+                section_content_str = '\n'.join(section_content)
+                section_content_str = pattern.sub('', section_content_str)
+                statement = self.create_statement(
+                    statement_id, section_content_str.strip()
+                )
+                implemented_req.statements.append(statement)
+
+    def create_statement(self, statement_id, description):
+        """Create a statement."""
+        statement = generate_sample_model(Statement)
+        statement.statement_id = statement_id
+        statement.description = description
+        return statement
+
+    def create_control_implementation(self):
+        """Get the control implementation for a component."""
+        ci = generate_sample_model(ControlImplementation)
+        ci.source = self.profile_href
+        all_implement_reqs = list()
+        for control in self.controls_mgr.get_all_controls(self.policy_id):
+            implemented_req = self.create_implemented_requirement(control)
+            if implemented_req:
+                all_implement_reqs.append(implemented_req)
+        ci.implemented_requirements = all_implement_reqs
+        return ci
+
+    def create_cd(self, output, component_definition_type="service"):
+        """Create a component definition and write it to a file."""
+        logger.info(f"Creating component definition for {self.product}")
+        component_definition = generate_sample_model(ComponentDefinition)
+        component_definition.metadata.title = f"Component definition for {self.product}"
+        component_definition.components = list()
+
+        control_implementation = self.create_control_implementation()
+
+        if not control_implementation.implemented_requirements:
+            logger.warning(
+                f"No implemented requirements found for {self.product}, exiting"
+            )
+            return
+
+        oscal_component = DefinedComponent(
+            uuid=str(uuid.uuid4()),
+            title=self.product,
+            type=component_definition_type,
+            description=self.product,
+            control_implementations=[control_implementation],
+        )
+        component_definition.components.append(oscal_component)
+
+        output_str = output
+        out_path = pathlib.Path(output_str)
+        logger.info(f"Writing component definition to {out_path}")
+        component_definition.oscal_write(out_path)


### PR DESCRIPTION
#### Description:

Add statement handling in OSCAL cd generation
Initial unit tests added for cd_generator to test this feature

Blocked by #2 

#### Rationale:

The control response processed and determined if there are sections with responses or a single response. The implemented requirement is updated accordingly.

#### Review Hints:

To test:
```bash
source .pyenv.sh
./build_product ocp4
./utils/rule_dir_json.py
./utils/oscal/build_cd_for_product.py -o test.json -p fedramp_rev4_high -pr ocp4 -c nist_ocp4
```
Unit tests run and passed here - https://github.com/jpower432/content/actions/runs/6804926955
Run unit tests:
```
source .pyenv.sh
pytest tests/unit/utils/oscal/
```






