### PR TITLE
feat(oscal): add response processes by status and property add

### DIFF
--- a/tests/unit/utils/oscal/test_cd_generator.py
+++ b/tests/unit/utils/oscal/test_cd_generator.py
@@ -101,7 +101,7 @@ A single response with no sections
     [
         (
             single_response,
-            Status.AUTOMATED,
+            Status.MANUAL,
             REPLACE_ME,
             OscalStatus.ALTERNATIVE,
             'A single response with no sections',

--- a/tests/unit/utils/oscal/test_cd_generator.py
+++ b/tests/unit/utils/oscal/test_cd_generator.py
@@ -6,6 +6,7 @@ import shutil
 
 from tempfile import TemporaryDirectory
 
+from trestle.common.const import IMPLEMENTATION_STATUS, REPLACE_ME
 from trestle.common.err import TrestleError
 from trestle.core.generators import generate_sample_model
 from trestle.common.model_utils import ModelUtils
@@ -15,7 +16,10 @@ from trestle.oscal import catalog as cat
 from trestle.oscal import profile as prof
 from trestle.oscal.component import ImplementedRequirement
 
-from utils.oscal.cd_generator import ComponentDefinitionGenerator
+from ssg.controls import Control, Status
+
+from utils.oscal.cd_generator import ComponentDefinitionGenerator, OscalStatus
+
 
 DATADIR = os.path.join(os.path.dirname(__file__), "data")
 TEST_ROOT = os.path.abspath(os.path.join(DATADIR, "test_root"))
@@ -63,7 +67,7 @@ def load_oscal_test_data(trestle_dir, model_name, model_type):
         ('AC-2(2)', 'ac-2.2'),
         ('ac-1_smt.a', 'ac-1_smt.a'),
         ('AC-200', None),
-    ]
+    ],
 )
 def test_get_control_profile_id(vendor_dir, input, response):
     "Test get_control_profile_id"
@@ -74,7 +78,7 @@ def test_get_control_profile_id(vendor_dir, input, response):
         json_path=TEST_RULE_JSON,
         root=TEST_ROOT,
         profile_name_or_href='simplified_nist_profile',
-        control="test_policy"
+        control="test_policy",
     )
     result_id = cd_generator.get_profile_control_id(input)
     assert result_id == response
@@ -92,8 +96,29 @@ A single response with no sections
 """
 
 
-def test_handle_response(vendor_dir):
-    """Test handling responses"""
+@pytest.mark.parametrize(
+    "notes, input_status, description, status, remarks",
+    [
+        (
+            single_response,
+            Status.AUTOMATED,
+            REPLACE_ME,
+            OscalStatus.ALTERNATIVE,
+            'A single response with no sections',
+        ),
+        (
+            single_response,
+            Status.INHERENTLY_MET,
+            'A single response with no sections',
+            OscalStatus.IMPLEMENTED,
+            None,
+        ),
+    ],
+)
+def test_handle_response_with_implemented_requirements(
+    vendor_dir, notes, input_status, description, status, remarks
+):
+    """Test handling responses with various scenarios."""
     cd_generator = ComponentDefinitionGenerator(
         product='test_product',
         vendor_dir=vendor_dir,
@@ -101,23 +126,99 @@ def test_handle_response(vendor_dir):
         json_path=TEST_RULE_JSON,
         root=TEST_ROOT,
         profile_name_or_href='simplified_nist_profile',
-        control="test_policy"
+        control="test_policy",
     )
 
-    # test with sections
+    control = Control()
+    control.notes = notes
+    control.status = input_status
+
     implemented_req = generate_sample_model(ImplementedRequirement)
     implemented_req.control_id = 'ac-1'
-    cd_generator.handle_response(implemented_req, section_response)
-
-    assert len(implemented_req.statements) == 2
-    assert implemented_req.statements[0].description == 'My response is a single statement'
-    expected_text = "My response is a list of statements\n\nThis link for section b."
-    assert implemented_req.statements[1].description == expected_text
-
-    # test single
-    implemented_req = generate_sample_model(ImplementedRequirement)
-    implemented_req.control_id = 'ac-1'
-    cd_generator.handle_response(implemented_req, single_response)
+    cd_generator.handle_response(implemented_req, control)
 
     assert implemented_req.statements is None
-    assert implemented_req.description == 'A single response with no sections'
+    assert implemented_req.description == description
+
+    prop = next(
+        (prop for prop in implemented_req.props if prop.name == IMPLEMENTATION_STATUS),
+        None,
+    )
+
+    assert prop is not None
+    assert prop.value == status
+    assert prop.remarks == remarks
+
+
+@pytest.mark.parametrize(
+    "notes, status, id, results",
+    [
+        (
+            section_response,
+            Status.PARTIAL,
+            'ac-1',
+            {
+                'ac-1_smt.a': (
+                    'My response is a single statement',
+                    OscalStatus.PARTIAL,
+                    None,
+                ),
+                'ac-1_smt.b': (
+                    'My response is a list of statements\n\nThis link for section b.',
+                    OscalStatus.PARTIAL,
+                    None,
+                ),
+            },
+        ),
+        (
+            section_response,
+            Status.MANUAL,
+            'ac-1',
+            {
+                'ac-1_smt.a': (
+                    REPLACE_ME,
+                    OscalStatus.ALTERNATIVE,
+                    'My response is a single statement',
+                ),
+                'ac-1_smt.b': (
+                    REPLACE_ME,
+                    OscalStatus.ALTERNATIVE,
+                    'My response is a list of statements\n\nThis link for section b.',
+                ),
+            },
+        ),
+    ],
+)
+def test_handle_response_with_statements(vendor_dir, notes, status, id, results):
+    """Test handling responses with various scenarios."""
+    cd_generator = ComponentDefinitionGenerator(
+        product='test_product',
+        vendor_dir=vendor_dir,
+        build_config_yaml=TEST_BUILD_CONFIG,
+        json_path=TEST_RULE_JSON,
+        root=TEST_ROOT,
+        profile_name_or_href='simplified_nist_profile',
+        control="test_policy",
+    )
+
+    control = Control()
+    control.notes = notes
+    control.status = status
+
+    implemented_req = generate_sample_model(ImplementedRequirement)
+    implemented_req.control_id = id
+    cd_generator.handle_response(implemented_req, control)
+
+    assert len(implemented_req.statements) == len(results)
+
+    for stm in implemented_req.statements:
+        description, status, remarks = results.get(stm.statement_id)
+        assert stm.description == description
+
+        prop = next(
+            (prop for prop in stm.props if prop.name == IMPLEMENTATION_STATUS), None
+        )
+
+        assert prop is not None
+        assert prop.value == status
+        assert prop.remarks == remarks

--- a/utils/oscal/cd_generator.py
+++ b/utils/oscal/cd_generator.py
@@ -36,7 +36,6 @@ logger = logging.getLogger(__name__)
 SECTION_PATTERN = r'Section ([a-z]):'
 
 
-# TODO: Verify that this is the correct way to handle the status
 class OscalStatus:
     PLANNED = "planned"
     NOT_APPLICABLE = "not-applicable"
@@ -49,12 +48,13 @@ class OscalStatus:
         data = {
             Status.INHERENTLY_MET: OscalStatus.IMPLEMENTED,
             Status.DOES_NOT_MEET: OscalStatus.ALTERNATIVE,
-            Status.NOT_APPLICABLE: OscalStatus.NOT_APPLICABLE,
-            Status.AUTOMATED: OscalStatus.ALTERNATIVE,
+            Status.DOCUMENTATION: OscalStatus.IMPLEMENTED,
+            Status.AUTOMATED: OscalStatus.IMPLEMENTED,
             Status.MANUAL: OscalStatus.ALTERNATIVE,
             Status.PLANNED: OscalStatus.PLANNED,
             Status.PARTIAL: OscalStatus.PARTIAL,
-            Status.SUPPORTED: OscalStatus.ALTERNATIVE,
+            Status.SUPPORTED: OscalStatus.IMPLEMENTED,
+            Status.PENDING: OscalStatus.ALTERNATIVE,
         }
         return data.get(source, source)
 

--- a/utils/oscal/cd_generator.py
+++ b/utils/oscal/cd_generator.py
@@ -9,11 +9,13 @@ import pathlib
 import re
 import uuid
 
-from trestle.common.const import TRESTLE_HREF_HEADING
+from trestle.common.const import TRESTLE_HREF_HEADING, IMPLEMENTATION_STATUS
+from trestle.common.list_utils import as_list
 from trestle.core.generators import generate_sample_model
 from trestle.core.catalog.catalog_interface import CatalogInterface
 from trestle.core.control_interface import ControlInterface
 from trestle.core.profile_resolver import ProfileResolver
+from trestle.oscal.common import Property
 from trestle.oscal.component import (
     ComponentDefinition,
     DefinedComponent,
@@ -26,12 +28,37 @@ import ssg.components
 import ssg.environment
 import ssg.rules
 import ssg.build_yaml
-from ssg.controls import ControlsManager
+from ssg.controls import ControlsManager, Status
 
 
 logger = logging.getLogger(__name__)
 
 SECTION_PATTERN = r'Section ([a-z]):'
+
+
+# TODO: Verify that this is the correct way to handle the status
+class OscalStatus:
+    PLANNED = "planned"
+    NOT_APPLICABLE = "not-applicable"
+    ALTERNATIVE = "alternative"
+    IMPLEMENTED = "implemented"
+    PARTIAL = "partial"
+
+    @staticmethod
+    def from_string(source: str) -> str:
+        data = {
+            Status.INHERENTLY_MET: OscalStatus.IMPLEMENTED,
+            Status.DOES_NOT_MEET: OscalStatus.ALTERNATIVE,
+            Status.NOT_APPLICABLE: OscalStatus.NOT_APPLICABLE,
+            Status.AUTOMATED: OscalStatus.ALTERNATIVE,
+            Status.MANUAL: OscalStatus.ALTERNATIVE,
+            Status.PLANNED: OscalStatus.PLANNED,
+            Status.PARTIAL: OscalStatus.PARTIAL,
+            Status.SUPPORTED: OscalStatus.ALTERNATIVE,
+        }
+        return data.get(source, source)
+
+    STATUSES = {PLANNED, NOT_APPLICABLE, ALTERNATIVE, IMPLEMENTED, PARTIAL}
 
 
 class ComponentDefinitionGenerator:
@@ -191,13 +218,12 @@ class ComponentDefinitionGenerator:
         if control_id:
             implemented_req = generate_sample_model(ImplementedRequirement)
             implemented_req.control_id = control_id
-            self.handle_response(implemented_req, control.notes)
+            self.handle_response(implemented_req, control)
             # TODO(jpower432): Setup rules in the properties file
-            # TODO(jpower432): Set the implementation status property
             return implemented_req
         return None
 
-    def handle_response(self, implemented_req, control_response):
+    def handle_response(self, implemented_req, control):
         """
         Break down the response into parts.
 
@@ -205,6 +231,7 @@ class ComponentDefinitionGenerator:
             implemented_req: The implemented requirement to add the response and statements to.
             control_response: The control response to add to the implemented requirement.
         """
+        control_response = control.notes
         pattern = re.compile(SECTION_PATTERN, re.IGNORECASE)
         lines = control_response.split('\n')
 
@@ -220,8 +247,12 @@ class ComponentDefinitionGenerator:
             elif current_section_label is not None:
                 sections_dict[current_section_label].append(line)
 
+        oscal_status = OscalStatus.from_string(control.status)
+
         if not sections_dict:
-            implemented_req.description = control_response.strip()
+            self.add_response_by_status(
+                implemented_req, oscal_status, control_response.strip()
+            )
         else:
             # process into statements
             implemented_req.statements = list()
@@ -234,16 +265,40 @@ class ComponentDefinitionGenerator:
 
                 section_content_str = '\n'.join(section_content)
                 section_content_str = pattern.sub('', section_content_str)
-                statement = self.create_statement(
-                    statement_id, section_content_str.strip()
+                statement = self.create_statement(statement_id)
+                self.add_response_by_status(
+                    statement, oscal_status, section_content_str.strip()
                 )
                 implemented_req.statements.append(statement)
 
-    def create_statement(self, statement_id, description):
+    def add_response_by_status(
+        self, type_with_props, implementation_status, control_response
+    ):
+        """
+        Add the response to the implemented requirement depending on the status.
+
+        Notes: Per OSCAL requirements, any status other than implemented and partial should have
+        remarks with justification for the status.
+        """
+
+        status_prop = Property(name=IMPLEMENTATION_STATUS, value=implementation_status)
+        if (
+            implementation_status == OscalStatus.IMPLEMENTED
+            or implementation_status == OscalStatus.PARTIAL
+        ):
+            type_with_props.description = control_response
+        else:
+            status_prop.remarks = control_response
+
+        type_with_props.props = as_list(type_with_props.props)
+        type_with_props.props.append(status_prop)
+
+    def create_statement(self, statement_id, description=""):
         """Create a statement."""
         statement = generate_sample_model(Statement)
         statement.statement_id = statement_id
-        statement.description = description
+        if description:
+            statement.description = description
         return statement
 
     def create_control_implementation(self):


### PR DESCRIPTION
#### Description:

Processes response based on status and adds mapping from SSG status to OSCAL status. Implemetation status property is added to conform to trestle convention.

Blocked by #3 

#### Rationale:

Responses that were originally stored in description are moved to remarks for certain status types where the OSCAL guidance denotes that justification is needed.

#### Review Hints:

Tests passed here - https://github.com/jpower432/content/actions/runs/6864519795

To test:
```bash
source .pyenv.sh
./build_product ocp4
./utils/rule_dir_json.py
./utils/oscal/build_cd_for_product.py -o test.json -p fedramp_rev4_high -pr ocp4 -c nist_ocp4
```

Run unit tests:
```
source .pyenv.sh
pytest tests/unit/utils/oscal/
```