### PR TITLE
chore: adds type hints and refactor OSCAL profile handling

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,7 @@ endmacro()
 
 mypy_test("utils/import_srg_spreadsheet.py")
 mypy_test("utils/check_eof.py")
+mypy_test("utils/oscal/")
 
 if(PYTHON_VERSION_MAJOR GREATER 2 AND PY_OPENPYXL AND PY_PANDAS AND SSG_PRODUCT_RHEL9)
     add_test(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,20 +83,20 @@ set_tests_properties("fix_rules" PROPERTIES LABELS quick)
 set_tests_properties("fix_rules" PROPERTIES DEPENDS "test-rule-dir-json")
 set_tests_properties("fix_rules" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
 
-macro(mypy_test SCRIPT)
+macro(mypy_test SCRIPT FOLLOW_IMPORTS)
     if(PY_MYPY)
         add_test(
             NAME "test-mypy-${SCRIPT}"
-            COMMAND env "${PYTHON_EXECUTABLE}" -m mypy "${CMAKE_SOURCE_DIR}/${SCRIPT}"
+            COMMAND env "${PYTHON_EXECUTABLE}" -m mypy "${CMAKE_SOURCE_DIR}/${SCRIPT}" "--follow-imports=${FOLLOW_IMPORTS}"
         )
         set_tests_properties("test-mypy-${SCRIPT}" PROPERTIES LABELS quick)
         set_tests_properties("test-mypy-${SCRIPT}" PROPERTIES LABELS mypy)
     endif()
 endmacro()
 
-mypy_test("utils/import_srg_spreadsheet.py")
-mypy_test("utils/check_eof.py")
-mypy_test("utils/oscal/")
+mypy_test("utils/import_srg_spreadsheet.py" "normal")
+mypy_test("utils/check_eof.py" "normal")
+mypy_test("utils/oscal/" "skip")
 
 if(PYTHON_VERSION_MAJOR GREATER 2 AND PY_OPENPYXL AND PY_PANDAS AND SSG_PRODUCT_RHEL9)
     add_test(

--- a/tests/unit/utils/oscal/data/test_root/products/test_product/product.yml
+++ b/tests/unit/utils/oscal/data/test_root/products/test_product/product.yml
@@ -1,4 +1,4 @@
-product: ocp4
+product: test_product
 full_name: Red Hat OpenShift Container Platform 4
 type: platform
 

--- a/tests/unit/utils/oscal/test_cd_generator.py
+++ b/tests/unit/utils/oscal/test_cd_generator.py
@@ -18,7 +18,11 @@ from trestle.oscal.component import ImplementedRequirement
 
 from ssg.controls import Control, Status
 
-from utils.oscal.cd_generator import ComponentDefinitionGenerator, OscalStatus
+from utils.oscal.cd_generator import (
+    ComponentDefinitionGenerator,
+    OscalStatus,
+    OSCALProfileHelper,
+)
 
 
 DATADIR = os.path.join(os.path.dirname(__file__), "data")
@@ -69,18 +73,13 @@ def load_oscal_test_data(trestle_dir, model_name, model_type):
         ('AC-200', None),
     ],
 )
-def test_get_control_profile_id(vendor_dir, input, response):
-    "Test get_control_profile_id"
-    cd_generator = ComponentDefinitionGenerator(
-        product='test_product',
-        vendor_dir=vendor_dir,
-        build_config_yaml=TEST_BUILD_CONFIG,
-        json_path=TEST_RULE_JSON,
-        root=TEST_ROOT,
-        profile_name_or_href='simplified_nist_profile',
-        control="test_policy",
-    )
-    result_id = cd_generator.get_profile_control_id(input)
+def test_oscal_profile_helper(vendor_dir, input, response):
+    "Test the OSCALProfileHelper class validate method."
+    trestle_root = pathlib.Path(vendor_dir)
+    oscal_profile_helper = OSCALProfileHelper(trestle_root=trestle_root)
+    profile_path = f'{vendor_dir}/profiles/simplified_nist_profile/profile.json'
+    oscal_profile_helper.load(profile_path=profile_path)
+    result_id = oscal_profile_helper.validate(input)
     assert result_id == response
 
 

--- a/utils/oscal/cd_generator.py
+++ b/utils/oscal/cd_generator.py
@@ -7,14 +7,16 @@ import logging
 import os
 import pathlib
 import re
-import uuid
+from typing import Any, Dict, Optional, Set, Tuple
 
+from trestle.common.common_types import TypeWithProps
 from trestle.common.const import TRESTLE_HREF_HEADING, IMPLEMENTATION_STATUS
 from trestle.common.list_utils import as_list
 from trestle.core.generators import generate_sample_model
 from trestle.core.catalog.catalog_interface import CatalogInterface
 from trestle.core.control_interface import ControlInterface
 from trestle.core.profile_resolver import ProfileResolver
+from trestle.oscal import catalog as cat
 from trestle.oscal.common import Property
 from trestle.oscal.component import (
     ComponentDefinition,
@@ -28,7 +30,7 @@ import ssg.components
 import ssg.environment
 import ssg.rules
 import ssg.build_yaml
-from ssg.controls import ControlsManager, Status
+from ssg.controls import ControlsManager, Status, Control
 
 
 logger = logging.getLogger(__name__)
@@ -66,14 +68,14 @@ class ComponentDefinitionGenerator:
 
     def __init__(
         self,
-        product,
-        root,
-        json_path,
-        build_config_yaml,
-        vendor_dir,
+        product: str,
+        root: str,
+        json_path: str,
+        build_config_yaml: str,
+        vendor_dir: str,
         profile_name_or_href,
-        control,
-    ):
+        control: str,
+    ) -> None:
         """
         Initialize the component definition generator and load the necessary files.
 
@@ -107,7 +109,7 @@ class ComponentDefinitionGenerator:
             rule_dir_json = json.load(f)
         self.rule_json = rule_dir_json
 
-    def get_env_yaml(self, build_config_yaml):
+    def get_env_yaml(self, build_config_yaml: str) -> Dict[str, Any]:
         """Get the environment yaml."""
         product_dir = os.path.join(self.ssg_root, "products", self.product)
         product_yaml_path = os.path.join(product_dir, "product.yml")
@@ -118,14 +120,14 @@ class ComponentDefinitionGenerator:
         )
         return env_yaml
 
-    def get_source(self, profile_name_or_href):
+    def get_source(self, profile_name_or_href: str) -> Tuple[str, str]:
         """Get the source of the profile."""
         profile_in_trestle_dir = '://' not in profile_name_or_href
         profile_href = profile_name_or_href
         if profile_in_trestle_dir:
             local_path = f'profiles/{profile_name_or_href}/profile.json'
             profile_href = TRESTLE_HREF_HEADING + local_path
-            profile_path = self.trestle_root / local_path
+            profile_path = str(self.trestle_root / local_path)
         else:
             profile_path = profile_href
 
@@ -142,7 +144,7 @@ class ComponentDefinitionGenerator:
             raise ValueError(f"Policy {control} not found in controls")
         return controls_manager
 
-    def resolve_profile_to_controls(self):
+    def resolve_profile_to_controls(self) -> Tuple[Set[str], Dict[str, str]]:
         """
         Resolve the profile to a list of control ids.
 
@@ -151,7 +153,7 @@ class ComponentDefinitionGenerator:
             controls_by_label: Dictionary of controls by label
         """
         profile_resolver = ProfileResolver()
-        resolved_catalog = profile_resolver.get_resolved_profile_catalog(
+        resolved_catalog: cat.Catalog = profile_resolver.get_resolved_profile_catalog(
             self.trestle_root,
             self.profile_path,
             block_params=False,
@@ -166,20 +168,25 @@ class ComponentDefinitionGenerator:
             label = ControlInterface.get_label(control)
             if label:
                 controls_by_label[label] = control.id
-                self.handle_parts(control, profile_controls, controls_by_label)
+                self._handle_parts(control, profile_controls, controls_by_label)
         return profile_controls, controls_by_label
 
-    def handle_parts(self, control, profile_controls, controls_by_label):
+    def _handle_parts(
+        self,
+        control: cat.Control,
+        profile_controls: Set[str],
+        controls_by_label: Dict[str, str],
+    ) -> None:
         """Handle parts of a control."""
         if control.parts:
             for part in control.parts:
-                profile_controls.add(part.id)
+                profile_controls.add(part.id)  # type: ignore
                 label = ControlInterface.get_label(part)
                 if label:
-                    controls_by_label[label] = part.id
-                self.handle_parts(part, profile_controls, controls_by_label)
+                    controls_by_label[label] = part.id  # type: ignore
+                self._handle_parts(part, profile_controls, controls_by_label)  # type: ignore
 
-    def handle_rule_yaml(self, rule_id: str):
+    def handle_rule_yaml(self, rule_id: str) -> Dict[str, str]:
         """Create rule object from rule yaml."""
         rule_dir = self.rule_json[rule_id]['dir']
         guide_dir = self.rule_json[rule_id]['guide']
@@ -193,7 +200,7 @@ class ComponentDefinitionGenerator:
         rule_obj['fixtext'] = rule_yaml.fixtext
         return rule_obj
 
-    def get_profile_control_id(self, control_name):
+    def get_profile_control_id(self, control_name: str) -> Optional[str]:
         """
         Get control info if it is in the parent profile.
 
@@ -210,7 +217,9 @@ class ComponentDefinitionGenerator:
         logger.debug(f"Control {control_name} does not exist in the profile")
         return None
 
-    def create_implemented_requirement(self, control):
+    def create_implemented_requirement(
+        self, control: Control
+    ) -> Optional[ImplementedRequirement]:
         """Create implemented requirement from a control object"""
 
         logger.info(f"Creating implemented requirement for {control.id}")
@@ -223,7 +232,7 @@ class ComponentDefinitionGenerator:
             return implemented_req
         return None
 
-    def handle_response(self, implemented_req, control):
+    def handle_response(self, implemented_req, control: Control) -> None:
         """
         Break down the response into parts.
 
@@ -250,7 +259,7 @@ class ComponentDefinitionGenerator:
         oscal_status = OscalStatus.from_string(control.status)
 
         if not sections_dict:
-            self.add_response_by_status(
+            self._add_response_by_status(
                 implemented_req, oscal_status, control_response.strip()
             )
         else:
@@ -266,14 +275,17 @@ class ComponentDefinitionGenerator:
                 section_content_str = '\n'.join(section_content)
                 section_content_str = pattern.sub('', section_content_str)
                 statement = self.create_statement(statement_id)
-                self.add_response_by_status(
+                self._add_response_by_status(
                     statement, oscal_status, section_content_str.strip()
                 )
                 implemented_req.statements.append(statement)
 
-    def add_response_by_status(
-        self, type_with_props, implementation_status, control_response
-    ):
+    @staticmethod
+    def _add_response_by_status(
+        type_with_props: TypeWithProps,
+        implementation_status: str,
+        control_response: str,
+    ) -> None:
         """
         Add the response to the implemented requirement depending on the status.
 
@@ -281,19 +293,21 @@ class ComponentDefinitionGenerator:
         remarks with justification for the status.
         """
 
-        status_prop = Property(name=IMPLEMENTATION_STATUS, value=implementation_status)
+        status_prop = Property(
+            name=IMPLEMENTATION_STATUS,
+            value=implementation_status)  # type: ignore
         if (
             implementation_status == OscalStatus.IMPLEMENTED
             or implementation_status == OscalStatus.PARTIAL
         ):
-            type_with_props.description = control_response
+            type_with_props.description = control_response  # type: ignore
         else:
             status_prop.remarks = control_response
 
         type_with_props.props = as_list(type_with_props.props)
         type_with_props.props.append(status_prop)
 
-    def create_statement(self, statement_id, description=""):
+    def create_statement(self, statement_id, description="") -> Statement:
         """Create a statement."""
         statement = generate_sample_model(Statement)
         statement.statement_id = statement_id
@@ -301,7 +315,7 @@ class ComponentDefinitionGenerator:
             statement.description = description
         return statement
 
-    def create_control_implementation(self):
+    def create_control_implementation(self) -> ControlImplementation:
         """Get the control implementation for a component."""
         ci = generate_sample_model(ControlImplementation)
         ci.source = self.profile_href
@@ -313,14 +327,18 @@ class ComponentDefinitionGenerator:
         ci.implemented_requirements = all_implement_reqs
         return ci
 
-    def create_cd(self, output, component_definition_type="service"):
+    def create_cd(
+        self, output: str, component_definition_type: str = "service"
+    ) -> None:
         """Create a component definition and write it to a file."""
         logger.info(f"Creating component definition for {self.product}")
         component_definition = generate_sample_model(ComponentDefinition)
         component_definition.metadata.title = f"Component definition for {self.product}"
         component_definition.components = list()
 
-        control_implementation = self.create_control_implementation()
+        control_implementation: ControlImplementation = (
+            self.create_control_implementation()
+        )
 
         if not control_implementation.implemented_requirements:
             logger.warning(
@@ -328,13 +346,12 @@ class ComponentDefinitionGenerator:
             )
             return
 
-        oscal_component = DefinedComponent(
-            uuid=str(uuid.uuid4()),
-            title=self.product,
-            type=component_definition_type,
-            description=self.product,
-            control_implementations=[control_implementation],
-        )
+        oscal_component = generate_sample_model(DefinedComponent)
+        oscal_component.title = self.product
+        oscal_component.type = component_definition_type
+        oscal_component.description = self.product
+        oscal_component.control_implementations = [control_implementation]
+
         component_definition.components.append(oscal_component)
 
         output_str = output

--- a/utils/oscal/cd_generator.py
+++ b/utils/oscal/cd_generator.py
@@ -9,7 +9,7 @@ import pathlib
 import re
 from typing import Any, Dict, Optional, Set, Tuple
 
-from trestle.common.common_types import TypeWithProps
+from trestle.common.common_types import TypeWithProps, TypeWithParts
 from trestle.common.const import TRESTLE_HREF_HEADING, IMPLEMENTATION_STATUS
 from trestle.common.list_utils import as_list
 from trestle.core.generators import generate_sample_model
@@ -63,6 +63,61 @@ class OscalStatus:
     STATUSES = {PLANNED, NOT_APPLICABLE, ALTERNATIVE, IMPLEMENTED, PARTIAL}
 
 
+class OSCALProfileHelper:
+    """Helper class to handle OSCAL profile."""
+
+    def __init__(self, trestle_root: pathlib.Path) -> None:
+        """Initialize."""
+        self._root = trestle_root
+        self.profile_controls: Set[str] = set()
+        self.controls_by_label: Dict[str, str] = dict()
+
+    def load(self, profile_path: str) -> None:
+        """Load the profile catalog."""
+        profile_resolver = ProfileResolver()
+        resolved_catalog: cat.Catalog = profile_resolver.get_resolved_profile_catalog(
+            self._root,
+            profile_path,
+            block_params=False,
+            params_format='[.]',
+            show_value_warnings=True,
+        )
+
+        for control in CatalogInterface(resolved_catalog).get_all_controls_from_dict():
+            self.profile_controls.add(control.id)
+            label = ControlInterface.get_label(control)
+            if label:
+                self.controls_by_label[label] = control.id
+                self._handle_parts(control)
+
+    def _handle_parts(
+        self,
+        control: TypeWithParts,
+    ) -> None:
+        """Handle parts of a control."""
+        if control.parts:
+            for part in control.parts:
+                if not part.id:
+                    continue
+                self.profile_controls.add(part.id)
+                label = ControlInterface.get_label(part)
+                if label:
+                    self.controls_by_label[label] = part.id
+                self._handle_parts(part)
+
+    def validate(self, control_id: str) -> Optional[str]:
+        """Validate that the control id exists in the catalog and return the id"""
+        if control_id in self.controls_by_label.keys():
+            logging.debug(f"Found control {control_id} in control labels")
+            return self.controls_by_label.get(control_id)
+        elif control_id in self.profile_controls:
+            logging.debug(f"Found control {control_id} in profile control ids")
+            return control_id
+
+        logger.debug(f"Control {control_id} does not exist in the profile")
+        return None
+
+
 class ComponentDefinitionGenerator:
     """Generate a component definition from a product"""
 
@@ -92,14 +147,10 @@ class ComponentDefinitionGenerator:
         self.product = product
 
         profile_path, profile_href = self.get_source(profile_name_or_href)
-        self.profile_path = profile_path
         self.profile_href = profile_href
 
-        # Used to match by profile control id and then by label property
-        (
-            self.profile_controls,
-            self.controls_by_label,
-        ) = self.resolve_profile_to_controls()
+        self.profile = OSCALProfileHelper(self.trestle_root)
+        self.profile.load(profile_path)
 
         self.env_yaml = self.get_env_yaml(build_config_yaml)
         self.policy_id = control
@@ -144,86 +195,13 @@ class ComponentDefinitionGenerator:
             raise ValueError(f"Policy {control} not found in controls")
         return controls_manager
 
-    def resolve_profile_to_controls(self) -> Tuple[Set[str], Dict[str, str]]:
-        """
-        Resolve the profile to a list of control ids.
-
-        Returns:
-            profile_controls: List of control ids in the profile
-            controls_by_label: Dictionary of controls by label
-        """
-        profile_resolver = ProfileResolver()
-        resolved_catalog: cat.Catalog = profile_resolver.get_resolved_profile_catalog(
-            self.trestle_root,
-            self.profile_path,
-            block_params=False,
-            params_format='[.]',
-            show_value_warnings=True,
-        )
-        profile_controls = set()
-        controls_by_label = dict()
-
-        for control in CatalogInterface(resolved_catalog).get_all_controls_from_dict():
-            profile_controls.add(control.id)
-            label = ControlInterface.get_label(control)
-            if label:
-                controls_by_label[label] = control.id
-                self._handle_parts(control, profile_controls, controls_by_label)
-        return profile_controls, controls_by_label
-
-    def _handle_parts(
-        self,
-        control: cat.Control,
-        profile_controls: Set[str],
-        controls_by_label: Dict[str, str],
-    ) -> None:
-        """Handle parts of a control."""
-        if control.parts:
-            for part in control.parts:
-                profile_controls.add(part.id)  # type: ignore
-                label = ControlInterface.get_label(part)
-                if label:
-                    controls_by_label[label] = part.id  # type: ignore
-                self._handle_parts(part, profile_controls, controls_by_label)  # type: ignore
-
-    def handle_rule_yaml(self, rule_id: str) -> Dict[str, str]:
-        """Create rule object from rule yaml."""
-        rule_dir = self.rule_json[rule_id]['dir']
-        guide_dir = self.rule_json[rule_id]['guide']
-        product = self.env_yaml['product']
-        rule_obj = {'id': rule_id, 'dir': rule_dir, 'guide': guide_dir}
-        rule_file = ssg.rules.get_rule_dir_yaml(rule_dir)
-
-        rule_yaml = ssg.build_yaml.Rule.from_yaml(rule_file, env_yaml=self.env_yaml)
-        rule_yaml.normalize(product)
-        rule_obj['description'] = rule_yaml.description
-        rule_obj['fixtext'] = rule_yaml.fixtext
-        return rule_obj
-
-    def get_profile_control_id(self, control_name: str) -> Optional[str]:
-        """
-        Get control info if it is in the parent profile.
-
-        Returns:
-            control_id: The control id if it is in the profile
-        """
-        if control_name in self.controls_by_label.keys():
-            logging.debug(f"Found control {control_name} in control labels")
-            return self.controls_by_label.get(control_name)
-        elif control_name in self.profile_controls:
-            logging.debug(f"Found control {control_name} in profile control ids")
-            return control_name
-
-        logger.debug(f"Control {control_name} does not exist in the profile")
-        return None
-
     def create_implemented_requirement(
         self, control: Control
     ) -> Optional[ImplementedRequirement]:
         """Create implemented requirement from a control object"""
 
         logger.info(f"Creating implemented requirement for {control.id}")
-        control_id = self.get_profile_control_id(control.id)
+        control_id = self.profile.validate(control.id)
         if control_id:
             implemented_req = generate_sample_model(ImplementedRequirement)
             implemented_req.control_id = control_id
@@ -266,7 +244,7 @@ class ComponentDefinitionGenerator:
             # process into statements
             implemented_req.statements = list()
             for section_label, section_content in sections_dict.items():
-                statement_id = self.get_profile_control_id(
+                statement_id = self.profile.validate(
                     f"{implemented_req.control_id}_smt.{section_label}"
                 )
                 if statement_id is None:
@@ -294,8 +272,8 @@ class ComponentDefinitionGenerator:
         """
 
         status_prop = Property(
-            name=IMPLEMENTATION_STATUS,
-            value=implementation_status)  # type: ignore
+            name=IMPLEMENTATION_STATUS, value=implementation_status
+        )  # type: ignore
         if (
             implementation_status == OscalStatus.IMPLEMENTED
             or implementation_status == OscalStatus.PARTIAL


### PR DESCRIPTION
#### Description:

Blocked by #4 

#### Rationale:

Adding type hints and mypy testing per the CaC developer guide
The `ComponentDefinitionGenerator` was handling OSCAL profile logic. Moved into a new class to conform to SRP.

#### Review Hints:

To test:
```bash
source .pyenv.sh
./build_product ocp4
./utils/rule_dir_json.py
./utils/oscal/build_cd_for_product.py -o test.json -p fedramp_rev4_high -pr ocp4 -c nist_ocp4
```
Tests passing here - https://github.com/jpower432/content/actions/runs/6881401265/job/18717665364
Run unit tests:
```
source .pyenv.sh
pytest tests/unit/utils/oscal/
```